### PR TITLE
feat: 테스트 커버리지 HTML 리포트 올리는 과정 추가

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -43,8 +43,20 @@ jobs:
       - name: Run build (includes ktlint/detekt/test check)
         run: ./gradlew build
 
-      - name: Generate merged xml report by Kover
-        run: ./gradlew koverMergedXmlReport
+      - name: Generate merged report by Kover
+        run: ./gradlew koverMergedReport
+
+      - name: Pushes report html to deploy repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: "report/test-coverage/"
+          destination-github-username: "sungbinland"
+          destination-repository-name: "duckie-quack-test-coverage-deploy"
+          user-email: ji@sungb.in
+          commit-message: |
+            #${{ github.event.number }} 에서 생성된 테스트 커버리지
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
## What's new?

1. Android CI 에 테스트 커버리지 HTML 리포트 [sungbinland/duckie-quack-test-coverage-deploy](https://github.com/sungbinland/duckie-quack-test-coverage-deploy) 레포지토리로 올리는 과정 추가 