### PR TITLE
Feat/fixed modifier order

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,13 +9,13 @@
 
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.DokkaBaseConfiguration
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
 
 plugins {
     alias(libs.plugins.detekt)

--- a/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/ComposeIssueRegistry.kt
+++ b/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/ComposeIssueRegistry.kt
@@ -24,6 +24,7 @@ import com.android.tools.lint.detector.api.Detector
 class ComposeIssueRegistry : IssueRegistry() {
     override val issues = listOf(
         PreferredImmutableCollectionsIssue,
+        FixedModifierOrderIssue,
     )
 
     override val api = CURRENT_API

--- a/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/FixedModifierOrderDetector.kt
+++ b/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/FixedModifierOrderDetector.kt
@@ -1,0 +1,95 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [FixedModifierOrderDetector.kt] created by riflockle7 on 22. 8. 28. 오후 11:09
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+@file:Suppress(
+    "UnstableApiUsage",
+    "SameParameterValue",
+)
+
+package team.duckie.quackquack.lint.compose
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.uast.UMethod
+import team.duckie.quackquack.common.lint.compose.isComposable
+import team.duckie.quackquack.common.lint.compose.isReturnsUnit
+
+private const val BriefDescription = "Modifier 인자를 첫 번째 위치 고정해야 함"
+private const val Explanation =
+    "Modifier 은 컴포저블의 필수 인자이므로, 매개변수 첫 번째 위치에 고정하여 도메인적 의미를 강조해야 합니다.\n(가장 많이 찾는 인자가 될 가능성이 높으니 첫 번째로 위치 고정을 함으로써 그 의미를 강화합니다.)"
+
+val FixedModifierOrderIssue = Issue.create(
+    id = "FixedModifierOrder",
+    briefDescription = BriefDescription,
+    explanation = Explanation,
+    category = Category.PERFORMANCE,
+    priority = 7,
+    severity = Severity.ERROR,
+    implementation = Implementation(
+        FixedModifierOrderDetector::class.java,
+        Scope.JAVA_FILE_SCOPE
+    )
+)
+
+/**
+ * QuackQuack 린트의 FixedModifierOrder 규칙을 구현합니다.
+ *
+ * 다음과 같은 조건에서 린트 검사를 진행합니다.
+ *
+ * 1. 컴포저블 함수여야 함
+ * 2. 컴포저블을 방출하는 역할이여야 함
+ *
+ * 다음과 같은 조건에서 린트 에러가 발생합니다.
+ *
+ * 1. 컴포저블 함수에서 1번째 인자가 Modifier 타입 변수가 아닐 경우 (Modifier 타입 변수가 인자로 없는 경우는 고려하지 않음)
+ *
+ * 현재 이 규칙은 인자 타입의 이름만을 이용하여 검사하도록 구현됐습니다.
+ * 따라서 아래와 같이 첫 번째 인자의 타입 네임을 체크하여
+ * 조건에 부합되지 않을 경우 린트 에러가 발생합니다.
+ *
+ * ```
+ * @Composable
+ * fun MyComposable(params: not Modifier, modifier: Modifier) {}
+ * //                       ~~~~~~~~~~~~ <- 첫 번째 인자 타입이 Modifier 가 아님
+ * // 첫 번째 인자 타입이 Modifier 가 아님을 인지하고 린트 에러가 발생함
+ * ```
+ *
+ * 인자 타입의 패키지를 이용하여 검사하는 것으로 구현이 개선돼야 합니다.
+ */
+class FixedModifierOrderDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableUastTypes() = listOf(UMethod::class.java)
+
+    override fun createUastHandler(context: JavaContext) = object : UElementHandler() {
+        override fun visitMethod(node: UMethod) {
+            if (!node.isComposable || !node.isReturnsUnit) return
+
+            val firstParameter =
+                node.uastParameters.firstOrNull()?.sourcePsi as? KtParameter ?: return
+            val firstParameterType = firstParameter.typeReference ?: return
+            val firstParameterTypeName = firstParameterType.text ?: return
+
+            if (!firstParameterTypeName.lowercase().contains("modifier")) {
+                return context.report(
+                    issue = FixedModifierOrderIssue,
+                    scope = firstParameterType,
+                    location = context.getNameLocation(firstParameterType),
+                    message = Explanation,
+                )
+            }
+        }
+    }
+}

--- a/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/FixedModifierOrderDetector.kt
+++ b/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/FixedModifierOrderDetector.kt
@@ -64,8 +64,8 @@ val FixedModifierOrderIssue = Issue.create(
  *
  * ```
  * @Composable
- * fun MyComposable(params: not Modifier, modifier: Modifier) {}
- * //                       ~~~~~~~~~~~~ <- 첫 번째 인자 타입이 Modifier 가 아님
+ * fun MyComposable(wrapperModifier: WrapperModifier, modifier: Modifier) {}
+ * //                                ~~~~~~~~~~~~~~~ <- 첫 번째 인자 타입이 Modifier 가 아님
  * // 첫 번째 인자 타입이 Modifier 가 아님을 인지하고 린트 에러가 발생함
  * ```
  *

--- a/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/FixedModifierOrderDetector.kt
+++ b/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/FixedModifierOrderDetector.kt
@@ -28,9 +28,10 @@ import org.jetbrains.uast.UMethod
 import team.duckie.quackquack.common.lint.compose.isComposable
 import team.duckie.quackquack.common.lint.compose.isReturnsUnit
 
-private const val BriefDescription = "Modifier 인자를 첫 번째 위치 고정해야 함"
-private const val Explanation =
-    "Modifier 은 컴포저블의 필수 인자이므로, 매개변수 첫 번째 위치에 고정하여 도메인적 의미를 강조해야 합니다.\n(가장 많이 찾는 인자가 될 가능성이 높으니 첫 번째로 위치 고정을 함으로써 그 의미를 강화합니다.)"
+private const val BriefDescription = "Modifier 인자를 첫 번째 위치로 고정해야 함"
+private const val Explanation = "Modifier 은 컴포저블의 필수 인자이므로, " +
+        "매개변수 첫 번째 위치에 고정하여 도메인적 의미를 강조해야 합니다.\n" +
+        "(가장 많이 찾는 인자가 될 가능성이 높으니 첫 번째로 위치 고정을 함으로써 그 의미를 강화합니다.)"
 
 val FixedModifierOrderIssue = Issue.create(
     id = "FixedModifierOrder",
@@ -55,7 +56,7 @@ val FixedModifierOrderIssue = Issue.create(
  *
  * 다음과 같은 조건에서 린트 에러가 발생합니다.
  *
- * 1. 컴포저블 함수에서 1번째 인자가 Modifier 타입 변수가 아닐 경우 (Modifier 타입 변수가 인자로 없는 경우는 고려하지 않음)
+ * 1. 컴포저블 함수에서 첫 번째 인자가 Modifier 타입 변수가 아닐 경우 (Modifier 타입 변수가 인자로 없는 경우는 고려하지 않음)
  *
  * 현재 이 규칙은 인자 타입의 이름만을 이용하여 검사하도록 구현됐습니다.
  * 따라서 아래와 같이 첫 번째 인자의 타입 네임을 체크하여

--- a/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/FixedModifierOrderTest.kt
+++ b/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/FixedModifierOrderTest.kt
@@ -18,12 +18,14 @@ import team.duckie.quackquack.common.lint.test.composableTestFile
  * 테스트 성공 조건
  * 1. 컴포저블 함수여야 함
  * 2. 컴포저블을 방출하는 역할이여야 함
- * 3. 컴포저블 함수에서 1번째 매개변수는 Modifier 타입 변수여야 함 (Modifier 타입 변수가 인자로 없는 경우는 고려하지 않음)
+ * 3. Composable 함수는 첫 번째 매개변수로 Modifier 만 사용해야 함 (Modifier 타입 변수가 인자로 없는 경우는 고려하지 않음)
+ * 4. Composable 함수의 첫 번째 매개변수가 Modifier 가 아닌 경우 오류가 발생함
  */
 class FixedModifierOrderTest {
     @get:Rule
     val lintTestRule = LintTestRule()
 
+    // TODO (riflockle7) 추후 성빈님 리펙터링 필요
     @Test
     fun `Must Composable function`() {
         lintTestRule
@@ -32,7 +34,7 @@ class FixedModifierOrderTest {
                     composableTestFile(
                         """
                         @Composable
-                        fun list(modifier: Modifier) {}
+                        fun modifier(modifier: Modifier) {}
                         """
                     ),
                 ),
@@ -43,6 +45,7 @@ class FixedModifierOrderTest {
             )
     }
 
+    // TODO (riflockle7) 추후 성빈님 리펙터링 필요
     @Test
     fun `Composable function but not emitting composable`() {
         lintTestRule
@@ -50,8 +53,7 @@ class FixedModifierOrderTest {
                 files = listOf(
                     composableTestFile(
                         """
-                        @Composable
-                        fun list(modifier: Modifier, list: MutableList<Any>) = list
+                        fun modifier(modifier: Modifier, any: Any) = modifier
                         """
                     ),
                 ),
@@ -63,7 +65,7 @@ class FixedModifierOrderTest {
     }
 
     @Test
-    fun `Composable function's First Parameter type is Modifier`() {
+    fun `The Composable function takes only Modifier as the first parameter`() {
         lintTestRule
             .assertErrorCount(
                 files = listOf(
@@ -71,7 +73,23 @@ class FixedModifierOrderTest {
                         """
                         @Composable
                         fun firstParameterIsModifier(modifier: Modifier, list: MutableList<Any>)
+                        """
+                    ),
+                ),
+                issues = listOf(
+                    FixedModifierOrderIssue,
+                ),
+                expectedCount = 0,
+            )
+    }
 
+    @Test
+    fun `If the first parameter of the Composable function is not a Modifier, throws an error`() {
+        lintTestRule
+            .assertErrorCount(
+                files = listOf(
+                    composableTestFile(
+                        """
                         @Composable
                         fun secondParameterIsModifier(list: MutableList<Any>, modifier: Modifier)
                         """

--- a/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/FixedModifierOrderTest.kt
+++ b/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/FixedModifierOrderTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [FixedModifierOrderTest.kt] created by riflockle7 on 22. 8. 28. 오후 11:18
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.lint.compose
+
+import org.junit.Rule
+import org.junit.Test
+import team.duckie.quackquack.common.lint.test.LintTestRule
+import team.duckie.quackquack.common.lint.test.composableTestFile
+
+/**
+ * 테스트 성공 조건
+ * 1. 컴포저블 함수여야 함
+ * 2. 컴포저블을 방출하는 역할이여야 함
+ * 3. 컴포저블 함수에서 1번째 매개변수는 Modifier 타입 변수여야 함 (Modifier 타입 변수가 인자로 없는 경우는 고려하지 않음)
+ */
+class FixedModifierOrderTest {
+    @get:Rule
+    val lintTestRule = LintTestRule()
+
+    @Test
+    fun `Must Composable function`() {
+        lintTestRule
+            .assertErrorCount(
+                files = listOf(
+                    composableTestFile(
+                        """
+                        @Composable
+                        fun list(modifier: Modifier) {}
+                        """
+                    ),
+                ),
+                issues = listOf(
+                    FixedModifierOrderIssue,
+                ),
+                expectedCount = 0,
+            )
+    }
+
+    @Test
+    fun `Composable function but not emitting composable`() {
+        lintTestRule
+            .assertErrorCount(
+                files = listOf(
+                    composableTestFile(
+                        """
+                        @Composable
+                        fun list(modifier: Modifier, list: MutableList<Any>) = list
+                        """
+                    ),
+                ),
+                issues = listOf(
+                    FixedModifierOrderIssue,
+                ),
+                expectedCount = 0,
+            )
+    }
+
+    @Test
+    fun `Composable function's First Parameter type is Modifier`() {
+        lintTestRule
+            .assertErrorCount(
+                files = listOf(
+                    composableTestFile(
+                        """
+                        @Composable
+                        fun firstParameterIsModifier(modifier: Modifier, list: MutableList<Any>)
+
+                        @Composable
+                        fun secondParameterIsModifier(list: MutableList<Any>, modifier: Modifier)
+                        """
+                    ),
+                ),
+                issues = listOf(
+                    FixedModifierOrderIssue,
+                ),
+                expectedCount = 1,
+            )
+    }
+}

--- a/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/PreferredImmutableCollectionsTest.kt
+++ b/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/PreferredImmutableCollectionsTest.kt
@@ -28,6 +28,7 @@ class PreferredImmutableCollectionsTest {
     @get:Rule
     val lintTestRule = LintTestRule()
 
+    // TODO (riflockle7) 추후 성빈님 리펙터링 필요
     @Test
     fun `Composable function`() {
         lintTestRule
@@ -47,6 +48,7 @@ class PreferredImmutableCollectionsTest {
             )
     }
 
+    // TODO (riflockle7) 추후 성빈님 리펙터링 필요
     @Test
     fun `Composable function but not emitting composable`() {
         lintTestRule


### PR DESCRIPTION
## What's new?
1. FixedModifierOrderIssue 를 구현하였습니다.

참고
- 이번엔 `구현`과 `테스트 코드 작성`이 분리되어 있어 commit 별 체크가 가능합니다.
- PR 을 요청하는 Assignees 가 체크할 요소가 제법 있어보입니다. (ex. label)
  아래와 같이 체크 리스트를 추가하여, Assignees 가 놓친 내용이 없는지 체크할 수 있도록 하면 좋을 것 같습니다.

체크 리스트
- [ ] Reviewer 과 Assignees 를 확인했습니다.
- [ ] label 을 확인했습니다
- [x] 대괄호 사이에 x 를 넣어(`[x]`), 체크 표시가 가능합니다.