### PR TITLE
사용자 커스텀 타입 추가 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ keystore
 /report
 /ui-components/src/test/snapshots
 /ui-components/out/
+/lint-compose/quack-lint-custom-rule

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,13 +9,13 @@
 
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.DokkaBaseConfiguration
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
 
 plugins {
     alias(libs.plugins.detekt)

--- a/common-lint/build.gradle.kts
+++ b/common-lint/build.gradle.kts
@@ -13,3 +13,7 @@ plugins {
     id(PluginEnum.JvmKover)
     id(PluginEnum.JvmDokka)
 }
+
+dependencies {
+    implementation(libs.kotlin.stdlib)
+}

--- a/common-lint/src/main/kotlin/team/duckie/quackquack/common/lint/CustomRule.kt
+++ b/common-lint/src/main/kotlin/team/duckie/quackquack/common/lint/CustomRule.kt
@@ -1,0 +1,66 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [CustomRule.kt] created by Ji Sungbin on 22. 8. 29. 오전 6:17
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.common.lint
+
+internal object CustomRule {
+    @Suppress("UNCHECKED_CAST")
+    private fun getAllowList(
+        customRuleClass: Class<*>,
+        customRule: Any,
+    ): List<String> {
+        val getAllowList = customRuleClass.getDeclaredMethod("getAllowList")
+        return getAllowList(customRule) as List<String>
+    }
+
+    val Modifier = try {
+        val customRuleClass =
+            Class.forName("team.duckie.quackquack.lint.custom.rule.Custom_Modifier")
+        val customRule = customRuleClass.getDeclaredConstructor().newInstance()
+        getAllowList(
+            customRuleClass = customRuleClass,
+            customRule = customRule,
+        ).also { allowModifiers ->
+            println("사용자 추가 Modifier: ${allowModifiers.joinToString()}")
+        }
+    } catch (ignored: ClassNotFoundException) {
+        println("사용자 추가 Modifier 를 찾지 못했습니다. 기본값을 그대로 사용합니다.")
+        emptyList()
+    }
+
+    val Collection = try {
+        val customRuleClass =
+            Class.forName("team.duckie.quackquack.lint.custom.rule.Custom_Collection")
+        val customRule = customRuleClass.getDeclaredConstructor().newInstance()
+        getAllowList(
+            customRuleClass = customRuleClass,
+            customRule = customRule,
+        ).also { allowCollections ->
+            println("사용자 추가 Collection: ${allowCollections.joinToString()}")
+        }
+    } catch (ignored: ClassNotFoundException) {
+        println("사용자 추가 MutableCollection 을 찾지 못했습니다. 기본값을 그대로 사용합니다.")
+        emptyList()
+    }
+
+    val ImmutableCollection = try {
+        val customRuleClass =
+            Class.forName("team.duckie.quackquack.lint.custom.rule.Custom_ImmutableCollection")
+        val customRule = customRuleClass.getDeclaredConstructor().newInstance()
+        getAllowList(
+            customRuleClass = customRuleClass,
+            customRule = customRule,
+        ).also { allowImmutableCollections ->
+            println("사용자 추가 ImmutableCollection: ${allowImmutableCollections.joinToString()}")
+        }
+    } catch (ignored: ClassNotFoundException) {
+        println("사용자 추가 ImmutableCollection 을 찾지 못했습니다. 기본값을 그대로 사용합니다.")
+        emptyList()
+    }
+}

--- a/common-lint/src/main/kotlin/team/duckie/quackquack/common/lint/CustomRule.kt
+++ b/common-lint/src/main/kotlin/team/duckie/quackquack/common/lint/CustomRule.kt
@@ -9,58 +9,41 @@
 
 package team.duckie.quackquack.common.lint
 
+import java.io.File
+import java.io.IOException
+import java.nio.file.Paths
+import kotlin.io.path.absolutePathString
+
 internal object CustomRule {
+    private val rootPath = Paths.get("").absolutePathString()
+    private val defaultPath = "$rootPath/quack-lint-custom-rule"
+
     @Suppress("UNCHECKED_CAST")
     private fun getAllowList(
-        customRuleClass: Class<*>,
-        customRule: Any,
-    ): List<String> {
-        val getAllowList = customRuleClass.getDeclaredMethod("getAllowList")
-        return getAllowList(customRule) as List<String>
-    }
+        ruleName: String,
+    ) = File(defaultPath, "Custom_$ruleName.txt").also { println(it.absolutePath) }.readText().split("\n")
 
     val Modifier = try {
-        val customRuleClass =
-            Class.forName("team.duckie.quackquack.lint.custom.rule.Custom_Modifier")
-        val customRule = customRuleClass.getDeclaredConstructor().newInstance()
-        getAllowList(
-            customRuleClass = customRuleClass,
-            customRule = customRule,
-        ).also { allowModifiers ->
-            println("사용자 추가 Modifier: ${allowModifiers.joinToString()}")
-        }
-    } catch (ignored: ClassNotFoundException) {
+        getAllowList("Modifier")
+    } catch (ignored: IOException) {
         println("사용자 추가 Modifier 를 찾지 못했습니다. 기본값을 그대로 사용합니다.")
         emptyList()
     }
 
     val Collection = try {
-        val customRuleClass =
-            Class.forName("team.duckie.quackquack.lint.custom.rule.Custom_Collection")
-        val customRule = customRuleClass.getDeclaredConstructor().newInstance()
-        getAllowList(
-            customRuleClass = customRuleClass,
-            customRule = customRule,
-        ).also { allowCollections ->
-            println("사용자 추가 Collection: ${allowCollections.joinToString()}")
-        }
-    } catch (ignored: ClassNotFoundException) {
+        getAllowList("Collection")
+    } catch (ignored: IOException) {
         println("사용자 추가 MutableCollection 을 찾지 못했습니다. 기본값을 그대로 사용합니다.")
         emptyList()
     }
 
     val ImmutableCollection = try {
-        val customRuleClass =
-            Class.forName("team.duckie.quackquack.lint.custom.rule.Custom_ImmutableCollection")
-        val customRule = customRuleClass.getDeclaredConstructor().newInstance()
-        getAllowList(
-            customRuleClass = customRuleClass,
-            customRule = customRule,
-        ).also { allowImmutableCollections ->
-            println("사용자 추가 ImmutableCollection: ${allowImmutableCollections.joinToString()}")
+        getAllowList("ImmutableCollection").also {
+            println("사용자 추가 ImmutableListWrapper: $it")
         }
-    } catch (ignored: ClassNotFoundException) {
+    } catch (ignored: IOException) {
         println("사용자 추가 ImmutableCollection 을 찾지 못했습니다. 기본값을 그대로 사용합니다.")
+        println(ignored.message)
         emptyList()
     }
 }

--- a/common-lint/src/main/kotlin/team/duckie/quackquack/common/lint/MutableCollectionChecker.kt
+++ b/common-lint/src/main/kotlin/team/duckie/quackquack/common/lint/MutableCollectionChecker.kt
@@ -1,0 +1,56 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [MutableCollectionChecker.kt] created by Ji Sungbin on 22. 8. 20. 오후 4:16
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.common.lint
+
+import org.jetbrains.kotlin.psi.KtTypeReference
+
+/**
+ * MutableCollection 접미사들
+ *
+ * Collection 으로 판단돼야 하는 클래스들의 접미사 입니다.
+ * 사용자가 @Collection 어노테이션을 붙인 클래스들의 이름도 추가됩니다.
+ */
+private val CollectionsSuffix: List<String> = mutableListOf(
+    "Collection",
+    "List",
+    "Set",
+    "Map",
+).apply {
+    addAll(CustomRule.Collection)
+}
+
+/**
+ * ImmutableCollection 이름들
+ *
+ * kotlinx.collections.immutable 패키지에 있는 Collection 이름들 입니다.
+ * 사용자가 @ImmutableCollection 어노테이션을 붙인 클래스들의 이름도 추가됩니다.
+ */
+private val ImmutableCollectionsName: List<String> = mutableListOf(
+    "ImmutableCollection",
+    "ImmutableList",
+    "ImmutableSet",
+    "ImmutableMap",
+    "PersistentCollection",
+    "PersistentList",
+    "PersistentSet",
+    "PersistentMap",
+).apply {
+    addAll(CustomRule.ImmutableCollection)
+}
+
+private val KtTypeReference.isCollection
+    get() = CollectionsSuffix.any { suffix ->
+        // ListWrapper 같은 경우도 있어서 contains 로 체크 (endsWith 했다가 취소)
+        text.contains(suffix)
+    }
+
+private val KtTypeReference.isImmutableCollection get() = ImmutableCollectionsName.contains(text)
+
+val KtTypeReference.isMutableCollection get() = isCollection && !isImmutableCollection

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,8 @@ build-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradl
 build-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 build-kover = { module = "org.jetbrains.kotlinx:kover", version.ref = "kover" }
 
+ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
+
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-metadata = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version.ref = "kotlin-metadata" }
 

--- a/lint-compose/build.gradle.kts
+++ b/lint-compose/build.gradle.kts
@@ -16,5 +16,8 @@ plugins {
 }
 
 dependencies {
-    bundleInsides(projects.commonLintCompose)
+    bundleInsides(
+        projects.commonLint,
+        projects.commonLintCompose,
+    )
 }

--- a/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/PreferredImmutableCollectionsDetector.kt
+++ b/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/PreferredImmutableCollectionsDetector.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.uast.UMethod
 import team.duckie.quackquack.common.lint.compose.isComposable
 import team.duckie.quackquack.common.lint.compose.isReturnsUnit
+import team.duckie.quackquack.common.lint.isMutableCollection
 
 private const val BriefDescription = "MutableCollections 사용 감지됨"
 private const val Explanation = "Skippable 을 위해 ImmutableCollections 사용을 지향해야 합니다."
@@ -42,27 +43,6 @@ val PreferredImmutableCollectionsIssue = Issue.create(
         PreferredImmutableCollectionsDetector::class.java,
         Scope.JAVA_FILE_SCOPE
     )
-)
-
-/**
- * MutableCollections 접미사
- *
- * kotlin.collection 패키지에 있는 Collections 들 입니다.
- */
-private val CollectionNames = listOf(
-    "List",
-    "Map",
-    "Set",
-)
-
-/**
- * ImmutableCollections 접두사
- *
- * kotlinx.collections 패키지에 있는 Collections 들 입니다.
- */
-private val ImmutableNames = listOf(
-    "Immutable",
-    "Persistent",
 )
 
 /**
@@ -105,14 +85,7 @@ class PreferredImmutableCollectionsDetector : Detector(), SourceCodeScanner {
             for (parameter in node.uastParameters) {
                 val ktParameter = parameter.sourcePsi as? KtParameter ?: continue
                 val parameterType = ktParameter.typeReference ?: continue
-                val parameterTypeName = parameterType.text
-                val isCollection = CollectionNames.any { collectionName ->
-                    parameterTypeName.contains(collectionName)
-                }
-                val isImmutable = ImmutableNames.any { immutableName ->
-                    parameterTypeName.contains(immutableName)
-                }
-                if (isCollection && !isImmutable) {
+                if (parameterType.isMutableCollection) {
                     context.report(
                         issue = PreferredImmutableCollectionsIssue,
                         scope = parameterType,

--- a/lint-custom-rule-annotation/README.md
+++ b/lint-custom-rule-annotation/README.md
@@ -1,0 +1,3 @@
+### 현재 이 구현은 작동하지 않습니다.
+
+[#73](https://github.com/sungbinland/duckie-quack-quack/pull/73)

--- a/lint-custom-rule-annotation/build.gradle.kts
+++ b/lint-custom-rule-annotation/build.gradle.kts
@@ -1,12 +1,13 @@
 /*
  * Designed and developed by 2022 SungbinLand, Team Duckie
  *
- * [empty.kt] created by Ji Sungbin on 22. 8. 20. 오후 4:16
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 29. 오전 2:45
  *
  * Licensed under the MIT.
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */
 
-package team.duckie.quackquack.common.lint
-
-class Empty
+plugins {
+    id(PluginEnum.JvmLibrary)
+    id(PluginEnum.JvmDokka)
+}

--- a/lint-custom-rule-annotation/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/annotation/NewCollection.kt
+++ b/lint-custom-rule-annotation/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/annotation/NewCollection.kt
@@ -1,0 +1,14 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [NewCollection.kt] created by Ji Sungbin on 22. 8. 29. 오전 6:38
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.lint.custom.rule.annotation
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS)
+annotation class NewCollection

--- a/lint-custom-rule-annotation/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/annotation/NewImmutableCollection.kt
+++ b/lint-custom-rule-annotation/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/annotation/NewImmutableCollection.kt
@@ -1,0 +1,14 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [NewImmutableCollection.kt] created by Ji Sungbin on 22. 8. 29. 오전 6:39
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.lint.custom.rule.annotation
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS)
+annotation class NewImmutableCollection

--- a/lint-custom-rule-annotation/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/annotation/NewModifier.kt
+++ b/lint-custom-rule-annotation/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/annotation/NewModifier.kt
@@ -1,0 +1,14 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [NewModifier.kt] created by Ji Sungbin on 22. 8. 29. 오전 2:54
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.lint.custom.rule.annotation
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS)
+annotation class NewModifier

--- a/lint-custom-rule-processor/README.md
+++ b/lint-custom-rule-processor/README.md
@@ -1,0 +1,3 @@
+### 현재 이 구현은 작동하지 않습니다.
+
+[#73](https://github.com/sungbinland/duckie-quack-quack/pull/73)

--- a/lint-custom-rule-processor/build.gradle.kts
+++ b/lint-custom-rule-processor/build.gradle.kts
@@ -1,0 +1,20 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [build.gradle.kts] created by Ji Sungbin on 22. 8. 29. 오전 2:46
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+plugins {
+    id(PluginEnum.JvmLibrary)
+    id(PluginEnum.JvmDokka)
+}
+
+dependencies {
+    implementations(
+        projects.lintCustomRuleAnnotation,
+        libs.ksp.api,
+    )
+}

--- a/lint-custom-rule-processor/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/processor/CustomRuleProcessor.kt
+++ b/lint-custom-rule-processor/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/processor/CustomRuleProcessor.kt
@@ -1,0 +1,120 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [CustomLintProcessor.kt] created by Ji Sungbin on 22. 8. 29. 오전 2:47
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.lint.custom.rule.processor
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import java.io.IOException
+import java.io.OutputStreamWriter
+import team.duckie.quackquack.lint.custom.rule.annotation.NewCollection
+import team.duckie.quackquack.lint.custom.rule.annotation.NewImmutableCollection
+import team.duckie.quackquack.lint.custom.rule.annotation.NewModifier
+
+@Suppress("SameParameterValue")
+private fun createCustomRuleFile(
+    ruleName: String,
+    allowList: Set<String>,
+    logger: KSPLogger,
+    codeGenerator: CodeGenerator,
+) {
+    logger.warn("Creating custom rule file for $ruleName")
+    try {
+        val fileName = "Custom_$ruleName"
+        val allowListByString = allowList.joinToString { allow -> "\"$allow\"" }
+        val file = codeGenerator.createNewFile(
+            dependencies = Dependencies(aggregating = false),
+            packageName = "team.duckie.quackquack.lint.custom.rule",
+            fileName = fileName,
+        )
+        OutputStreamWriter(file, "UTF-8").use { stream ->
+            stream.write(
+                """
+                package team.duckie.quackquack.lint.custom.rule
+
+                class $fileName {
+                    val allowList = listOf<String>($allowListByString)
+                }
+                """.trimIndent()
+            )
+        }
+    } catch (exception: IOException) {
+        logger.error("Failed to create custom rule file for $ruleName. exception message: ${exception.message}")
+    } finally {
+        logger.warn("Finished creating custom rule file for $ruleName")
+    }
+}
+
+class CustomRuleProcessor(
+    private val logger: KSPLogger,
+    private val codeGenerator: CodeGenerator,
+) : SymbolProcessor {
+    private val newModifiers = mutableSetOf<String>()
+    private val newCollections = mutableSetOf<String>()
+    private val newImmutableCollections = mutableSetOf<String>()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        collectCustomRules(
+            resolver = resolver,
+            ruleAnnotation = NewModifier::class.java,
+            allowList = newModifiers
+        )
+        collectCustomRules(
+            resolver = resolver,
+            ruleAnnotation = NewCollection::class.java,
+            allowList = newCollections
+        )
+        collectCustomRules(
+            resolver = resolver,
+            ruleAnnotation = NewImmutableCollection::class.java,
+            allowList = newImmutableCollections
+        )
+        return emptyList()
+    }
+
+    override fun finish() {
+        super.finish()
+        listOf(
+            "Modifier" to newModifiers,
+            "Collection" to newCollections,
+            "ImmutableCollection" to newImmutableCollections,
+        ).forEach { (ruleName, allowList) ->
+            createCustomRuleFile(
+                ruleName = ruleName,
+                allowList = allowList,
+                logger = logger,
+                codeGenerator = codeGenerator
+            )
+        }
+    }
+
+    override fun onError() {
+        logger.error("Error on SymbolProcessor processing")
+    }
+
+    private fun collectCustomRules(
+        resolver: Resolver,
+        ruleAnnotation: Class<*>,
+        allowList: MutableSet<String>,
+    ) {
+        val symbols = resolver.getSymbolsWithAnnotation(ruleAnnotation.canonicalName)
+        logger.warn("found new ${ruleAnnotation.simpleName}: ${symbols.joinToString()}")
+        symbols
+            .filterIsInstance<KSClassDeclaration>()
+            .forEach { classDeclaration ->
+                val name = classDeclaration.simpleName.asString()
+                allowList.add(name)
+            }
+    }
+}

--- a/lint-custom-rule-processor/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/processor/CustomRuleProcessor.kt
+++ b/lint-custom-rule-processor/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/processor/CustomRuleProcessor.kt
@@ -82,8 +82,7 @@ class CustomRuleProcessor(
                 ruleName = ruleName,
                 allowList = allowList,
                 logger = logger,
-                rootPath = options["path"]
-                    ?: throw IllegalStateException("project path is not defined")
+                rootPath = checkNotNull(options["path"]) { "project path is not defined" }
             )
         }
     }

--- a/lint-custom-rule-processor/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/processor/CustomRuleProcessorProvider.kt
+++ b/lint-custom-rule-processor/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/processor/CustomRuleProcessorProvider.kt
@@ -15,6 +15,6 @@ import com.google.devtools.ksp.processing.SymbolProcessorProvider
 class CustomRuleProcessorProvider : SymbolProcessorProvider {
     override fun create(environment: SymbolProcessorEnvironment) = CustomRuleProcessor(
         logger = environment.logger,
-        codeGenerator = environment.codeGenerator,
+        options = environment.options,
     )
 }

--- a/lint-custom-rule-processor/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/processor/CustomRuleProcessorProvider.kt
+++ b/lint-custom-rule-processor/src/main/kotlin/team/duckie/quackquack/lint/custom/rule/processor/CustomRuleProcessorProvider.kt
@@ -1,0 +1,20 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [CustomRuleProcessorProvider.kt] created by Ji Sungbin on 22. 8. 29. 오전 2:56
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.lint.custom.rule.processor
+
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+
+class CustomRuleProcessorProvider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment) = CustomRuleProcessor(
+        logger = environment.logger,
+        codeGenerator = environment.codeGenerator,
+    )
+}

--- a/lint-custom-rule-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/lint-custom-rule-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,10 @@
+#
+# Designed and developed by 2022 SungbinLand, Team Duckie
+#
+# [com.google.devtools.ksp.processing.SymbolProcessorProvider] created by Ji Sungbin on 22. 8. 29. 오전 3:08
+#
+# Licensed under the MIT.
+# Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+#
+
+team.duckie.quackquack.lint.custom.rule.processor.CustomRuleProcessorProvider

--- a/playground/build.gradle.kts
+++ b/playground/build.gradle.kts
@@ -54,6 +54,10 @@ android {
     lint {
         disable.add("NotificationPermission")
     }
+
+    ksp {
+        arg("path", "/Users/jisungbin/AndroidStudioProjects/duckie-quack-quack/lint-compose")
+    }
 }
 
 dependencies {

--- a/playground/build.gradle.kts
+++ b/playground/build.gradle.kts
@@ -7,13 +7,17 @@
  * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
  */
 
-@file:Suppress("UnstableApiUsage")
+@file:Suppress(
+    "UnstableApiUsage",
+    "DSL_SCOPE_VIOLATION",
+)
 
 plugins {
     id(PluginEnum.AndroidApplication)
     id(PluginEnum.AndroidApplicationCompose)
     id(PluginEnum.JvmKover)
     id(PluginEnum.JvmDokka)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -33,6 +37,13 @@ android {
             signingConfig = signingConfigs.getByName("release")
         }
 
+        sourceSets.getByName("debug") {
+            kotlin.srcDir("build/generated/ksp/debug/kotlin")
+        }
+        sourceSets.getByName("release") {
+            kotlin.srcDir("build/generated/ksp/release/kotlin")
+        }
+
         create("benchmark") {
             signingConfig = signingConfigs.getByName("debug")
             matchingFallbacks += listOf("release")
@@ -46,9 +57,14 @@ android {
 }
 
 dependencies {
-    implementations(projects.uiComponents)
+    implementations(
+        projects.common,
+        projects.uiComponents,
+        projects.lintCustomRuleAnnotation,
+    )
     customLints(
         projects.lintQuack,
         projects.lintCompose,
     )
+    ksp(projects.lintCustomRuleProcessor)
 }

--- a/playground/build.gradle.kts
+++ b/playground/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
     id(PluginEnum.AndroidApplicationCompose)
     id(PluginEnum.JvmKover)
     id(PluginEnum.JvmDokka)
-    alias(libs.plugins.ksp)
+    // alias(libs.plugins.ksp)
 }
 
 android {
@@ -55,9 +55,9 @@ android {
         disable.add("NotificationPermission")
     }
 
-    ksp {
+    /*ksp {
         arg("path", "/Users/jisungbin/AndroidStudioProjects/duckie-quack-quack/lint-compose")
-    }
+    }*/
 }
 
 dependencies {
@@ -70,5 +70,5 @@ dependencies {
         projects.lintQuack,
         projects.lintCompose,
     )
-    ksp(projects.lintCustomRuleProcessor)
+    // ksp(projects.lintCustomRuleProcessor)
 }

--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/CustomRule.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/CustomRule.kt
@@ -1,0 +1,24 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [CustomRule.kt] created by Ji Sungbin on 22. 8. 29. 오전 3:12
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.playground
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+import team.duckie.quackquack.lint.custom.rule.annotation.NewImmutableCollection
+import team.duckie.quackquack.lint.custom.rule.annotation.NewModifier
+
+@NewModifier
+@JvmInline
+value class ModifierWrapper(val modifier: Modifier)
+
+@NewImmutableCollection
+@Immutable
+@JvmInline
+value class ImmutableListWrapper(val list: List<Any>)

--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/MainActivity.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/MainActivity.kt
@@ -16,6 +16,7 @@
 package team.duckie.quackquack.playground
 
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
 
 class MainActivity : ComponentActivity()
 
@@ -39,3 +40,11 @@ fun PreferredMutableCollection(
 ) {
     // stub!
 }*/
+
+@Composable
+fun PreferredMutableCollection(
+    mutableList: List<Any>,
+    immutableList: ImmutableListWrapper,
+) {
+    // stub!
+}

--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/MainActivity.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/MainActivity.kt
@@ -16,7 +16,6 @@
 package team.duckie.quackquack.playground
 
 import androidx.activity.ComponentActivity
-import androidx.compose.runtime.Composable
 
 class MainActivity : ComponentActivity()
 
@@ -41,6 +40,7 @@ fun PreferredMutableCollection(
     // stub!
 }*/
 
+/*
 @Composable
 fun PreferredMutableCollection(
     mutableList: List<Any>,
@@ -48,3 +48,4 @@ fun PreferredMutableCollection(
 ) {
     // stub!
 }
+*/

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,4 +33,6 @@ include(
     ":lint-writing",
     ":ui-components",
     ":benchmark",
+    ":lint-custom-rule-annotation",
+    ":lint-custom-rule-processor",
 )


### PR DESCRIPTION
## What's new?

기존 린트의 타입 검사 구현은 허용하는 타입명을 정적으로 고정해 두고, 이 타입명에 있는 타입명만 허용하는 식으로 구현돼 있습니다. 예를 들어 PreferredImmutableCollections 의 경우에는 아래와 같은 경우엔 올바른 사용 사레 이지만, 허용하는 타입명에 존재하지 않는 타입이라 린트 에러가 발생합니다.

```kotlin
@Immutable
@JvmInline
value class ImmutableListWrapper(val list: List<Any>)
```

따라서 이와 같은 경우를 대응하기 위해 사용자 추가 클래스에 어노테이션을 붙여서, 해당 클래스명의 타입은 추가로 허용하는 기능을 구현했습니다. 위와 같은 상황에서 `@NewImmutableCollection` 어노테이션을 붙이면 `ImmutableListWrapper` 클래스는 PreferredImmutableCollections 에서 허용하는 타입이 됩니다.

```kotlin
@NewImmutableCollection // <-- new
@Immutable
@JvmInline
value class ImmutableListWrapper(val list: List<Any>)
```

`@NewImmutableCollection` 의외에 `@NewCollection`, `@NewModifier` 도 있습니다. 원래의 구현은 사용자 추가 어노테이션이 붙은 클래스명이 `Custom_${type}.kt` 로 빌드 폴더에 저장되고, 린트가 작동되는 시점에서 이 파일에 있는 내용들과 기존에 정적으로 추가돼 있던 타입명들을 합쳐서 검사합니다. 이 구현을 위해 ksp 에서 생성되는 빌드 폴더에 리플렉션으로 접근합니다. [`1e175dc10b`](https://github.com/sungbinland/duckie-quack-quack/tree/1e175dc10b2d33233cd8d3dce8f4ef0321d2ccc5)

```kotlin
internal object CustomRule {
    @Suppress("UNCHECKED_CAST")
    private fun getAllowList(
        customRuleClass: Class<*>, // Class<*> 인자 한개로 가능, 하지만 이 방식 자체가 한계가 있는 구현이여서 리펙토링 진행 X
        customRule: Any,
    ): List<String> {
        val getAllowList = customRuleClass.getDeclaredMethod("getAllowList")
        return getAllowList(customRule) as List<String>
    }

    val Modifier = try {
        val customRuleClass = Class.forName("team.duckie.quackquack.lint.custom.rule.Custom_Modifier")
        val customRule = customRuleClass.getDeclaredConstructor().newInstance()
        getAllowList(
            customRuleClass = customRuleClass,
            customRule = customRule,
        ).also { allowModifiers ->
            println("사용자 추가 Modifier: ${allowModifiers.joinToString()}")
        }
    } catch (ignored: ClassNotFoundException) {
        println("사용자 추가 Modifier 를 찾지 못했습니다. 기본값을 그대로 사용합니다.")
        emptyList()
    }

    // ...
}
```

하지만 이 방법이 성공하기 위해선 ksp 에서 생성되는 빌드 폴더가 린트 패키지에서 읽을 수 있어야 합니다. 따라서 이 방법을 사용하지 않고 파일을 일반 텍스트 파일로 일반 경로에 저장하는 방법으로 재구현 합니다. [`f5650a4efb`](https://github.com/sungbinland/duckie-quack-quack/tree/f5650a4efb3b5ba4f3ad820a871cfff681c52930)

```kotlin
internal object CustomRule {
    private val rootPath = Paths.get("").absolutePathString()
    private val defaultPath = "$rootPath/quack-lint-custom-rule"

    private fun getAllowList(
        ruleName: String,
    ) = File(defaultPath, "Custom_$ruleName.txt").also { println(it.absolutePath) }.readText().split("\n")

    val Modifier = try {
        getAllowList("Modifier")
    } catch (ignored: IOException) {
        println("사용자 추가 Modifier 를 찾지 못했습니다. 기본값을 그대로 사용합니다.")
        emptyList()
    }

    // ...
}
```

하지만 이 방법은 ksp 가 작동될 때의 working directory 와 린트가 작동될 때의 working directory 가 달라서 매번 rootPath 의 값이 달라집니다. 따라서 rootPath 를 이용하는 것이 아닌 바로 `quack-lint-custom-rule` 폴더로 접근하게 해보았지만 최상위 폴더를 새로 만드는 과정에서 실패하였습니다. (아마 권한 문제 같습니다)

마지막으로 시도해본 방법은 ksp 의 working directory 와 린트의 working directory 를 맞추기 위해 우선 린트의 working directory 를 디버그로 확인해 보았습니다. 확인 결과 현재 린트 패키지의 경로가 사용된다는 것을 확인할 수 있었고, ksp 가 해당 경로로 파일을 만들도록 해보았지만 작동하지 않았습니다. 아마 린트가 실제 작동되는 환경에서 working directory 가 달라지는거 같습니다. ([`f5650a4efb`](https://github.com/sungbinland/duckie-quack-quack/tree/f5650a4efb3b5ba4f3ad820a871cfff681c52930) 와 동일)

더 많은 시간을 이 기능에 할애하기엔 디자인 시스템 작업이 우선인지라 일단 여기에서 개발을 멈추고, 추후 다 같이 개선을 위해 PR 을 올립니다.

**현재 작동하지 않는 구현이기에 문서화와 일부 코드 스타일을 지키지 않았습니다.** 이 기능이 작동하게 재구현을 할 때 개선할 예정입니다.

## 체크 리스트

- [x] Reviewer 과 Assignees 를 확인했습니다.
- [x] label 을 확인했습니다
