### PR TITLE
RequireModifier 규칙 구현

### DIFF
--- a/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/ComposeIssueRegistry.kt
+++ b/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/ComposeIssueRegistry.kt
@@ -26,6 +26,7 @@ class ComposeIssueRegistry : IssueRegistry() {
         PreferredImmutableCollectionsIssue,
         TrailingCommaIssue,
         FixedModifierOrderIssue,
+        RequireModifierIssue,
     )
 
     override val api = CURRENT_API

--- a/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/RequireModifierDetector.kt
+++ b/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/RequireModifierDetector.kt
@@ -1,0 +1,80 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [RequireModifierDetector.kt] created by limsaehyun on 22. 9. 2. 오후 1:36
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.lint.compose
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.name.SpecialNames
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.uast.UMethod
+import team.duckie.quackquack.common.lint.compose.isComposable
+
+private const val BriefDescription = "Modifier Type 필수 사용"
+private const val Explanation = "컴포저블의 재사용성을 위해 Modifier Type은 필수적으로 사용해야 합니다."
+
+/**
+ * QuackQuack 린트의 [RequireModifierDetector] 규칙을 정의합니다.
+ *
+ * 다음과 같은 조건에서 린트를 검사합니다.
+ *
+ * 1. 컴포저블 함수여야 함
+ *
+ * 다음과 같은 조건에서 린트 에러가 발생합니다.
+ *
+ * 1. parameter에 Modifier Type 이 없는 경우
+ */
+val RequireModifierIssue = Issue.create(
+    id = "RequireModifier",
+    briefDescription = BriefDescription,
+    explanation = Explanation,
+    category = Category.CORRECTNESS,
+    priority = 7,
+    severity = Severity.ERROR,
+    implementation = Implementation(
+        RequireModifierDetector::class.java,
+        Scope.JAVA_FILE_SCOPE
+    )
+)
+
+class RequireModifierDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableUastTypes() = listOf(
+        UMethod::class.java
+    )
+
+    override fun createUastHandler(context: JavaContext) = object : UElementHandler() {
+
+        override fun visitMethod(node: UMethod) {
+            if (!node.isComposable) return
+
+            val modifierParameterExists = node.uastParameters.any { parameter ->
+                (parameter.sourcePsi as? KtParameter)?.typeReference?.text == "Modifier"
+            }
+
+            val parameterPsi = node.javaPsi.parameterList
+
+            if (!modifierParameterExists) {
+                context.report(
+                    issue = RequireModifierIssue,
+                    scope = parameterPsi,
+                    location = context.getLocation(parameterPsi),
+                    message = Explanation,
+                )
+            }
+        }
+    }
+}

--- a/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/RequireModifierDetector.kt
+++ b/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/RequireModifierDetector.kt
@@ -18,8 +18,6 @@ import com.android.tools.lint.detector.api.JavaContext
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
-import org.jetbrains.kotlin.name.SpecialNames
-import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.uast.UMethod
 import team.duckie.quackquack.common.lint.compose.isComposable

--- a/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/RequireModifierTest.kt
+++ b/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/RequireModifierTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [RequireModifierTest.kt] created by limsaehyun on 22. 9. 2. 오후 12:33
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+@file:Suppress(
+    "UnstableApiUsage",
+    "TestFunctionName"
+)
+
+package team.duckie.quackquack.lint.compose
+
+import org.junit.Rule
+import org.junit.Test
+import team.duckie.quackquack.common.lint.test.LintTestRule
+import team.duckie.quackquack.common.lint.test.composableTestFile
+
+/**
+ * 테스트 성공 조건
+ * 1. Composable 함수여야 함
+ * 2. parameter 타입으로 Modifier가 없을 경우 에러 방출
+ */
+class RequireModifierTest {
+
+    @get:Rule
+    val lintTestRule = LintTestRule()
+
+    @Test
+    fun `Modifier does NOT exist in parameter`() {
+        lintTestRule.assertErrorCount(
+            files = listOf(
+                composableTestFile(
+                    """
+                        @Composable
+                        fun success1(
+                            modifier: Modifier,
+                            a: String,
+                        ) {}
+
+                        @Composable
+                        fun success2(
+                            testModifier: Modifier,
+                        ) {}
+
+                        @Composable
+                        fun failed1() {}
+
+                        @Composable
+                        fun failed2(
+                            modifier: String,
+                        ) {}
+                """.trimIndent())
+            ),
+            issues = listOf(
+                RequireModifierIssue,
+            ),
+            expectedCount = 2,
+        )
+    }
+}

--- a/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/RequireModifierTest.kt
+++ b/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/RequireModifierTest.kt
@@ -53,7 +53,8 @@ class RequireModifierTest {
                         fun failed2(
                             modifier: String,
                         ) {}
-                """.trimIndent())
+                """.trimIndent()
+                )
             ),
             issues = listOf(
                 RequireModifierIssue,


### PR DESCRIPTION
## What's new?

1. RequireModifierIssue를 생성하였습니다.
2. RequireModifier의 테스트케이스를 작성하였습니다.
3. RequireModifierDetector를 구현하였습니다.

## 참고

- parameter의 type을 text로 비교하였습니다. 이 부분은 추후에 파일을 비교하는 형식으로 바뀌어야 합니다.
- design-system쪽에서 build error가 발생합니다. 이 부분으로 인해 build가 failed될 것으로 예상됩니다.

## 체크 리스트

- [x] Reviewer 과 Assignees 를 확인했습니다.
- [x] label 을 확인했습니다
