### PR TITLE
KDocFields 린트 규칙 구현

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -28,7 +28,7 @@ style:
 
 naming:
   TopLevelPropertyNaming:
-    constantPattern: '[A-Z가-힣][A-Za-z0-9가-힣]*'
+    constantPattern: '[A-Z가-힣][A-Za-z0-9가-힣_]*'
   FunctionNaming:
     ignoreAnnotated: [ 'Composable' ]
   MatchingDeclarationName:

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -28,7 +28,7 @@ style:
 
 naming:
   TopLevelPropertyNaming:
-    constantPattern: '[A-Z][A-Za-z0-9]*'
+    constantPattern: '[A-Z가-힣][A-Za-z0-9가-힣]*'
   FunctionNaming:
     ignoreAnnotated: [ 'Composable' ]
   MatchingDeclarationName:

--- a/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/CoreIssueRegistry.kt
+++ b/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/CoreIssueRegistry.kt
@@ -22,6 +22,7 @@ import com.android.tools.lint.detector.api.Detector
 class CoreIssueRegistry : IssueRegistry() {
     override val issues = listOf(
         MutableCollectionPublicIssue,
+        KDocFieldsIssue,
     )
 
     override val api = CURRENT_API

--- a/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/KDocFieldsDetector.kt
+++ b/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/KDocFieldsDetector.kt
@@ -23,7 +23,9 @@ import com.android.tools.lint.detector.api.JavaContext
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiType
 import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocSection
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -36,12 +38,12 @@ import org.jetbrains.uast.toUElement
 private const val BriefDescription = "함수에 KDoc 및 @param, @return, @throws 및 description 필수"
 private const val Explanation = "함수에 KDoc (/** and end with */)을 추가해야 합니다.\n" +
         "그리고 누락된 내용(@param, @return, @throws, @description) 이 없는지 체크해야 합니다."
-private const val ExplanationKDocNotExist = "함수에는 KDoc 이 명시되어야 합니다."
-private const val ExplanationParamCountNotEqual = "@param 명세 개수가, 매개 변수 개수가 일치해야 합니다."
-private const val ExplanationWrongParam1 = "@return, @throws, @description 에 오타가 있습니다"
-private const val ExplanationParamNotCompleted1 = "@return, @description 은 반드시 명세되어야 합니다 " +
-        "(@throws 는 필요에 따라 명세)"
-private const val ExplanationParamNotCompleted2 = "함수 내 매개변수가 있을 시, @param 는 반드시 명세되어야 합니다"
+private const val kDoc_명세_필요 = "함수에는 KDoc 이 명시되어야 합니다."
+private const val param_개수와_매개변수_개수_불일치 = "@param 명세 개수가, 매개 변수 개수가 일치해야 합니다."
+private const val return_명세_필요 = "@return 이 반드시 명세되어야 합니다 "
+private const val throws_명세_필요 = "@throws 이 반드시 명세되어야 합니다 "
+private const val param_명세_필요 = "함수 내 모든 매개변수에 대하여, @param 는 반드시 명세되어야 합니다"
+private const val annotation에_대응하는_내용_없음 = "어노태이션에 대응하는 내용이 반드시 있어야 합니다."
 
 val KDocFieldsIssue = Issue.create(
     id = "KDocFields",
@@ -72,18 +74,19 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
      * 그러므로 함수인 경우에 KDoc 스타일로 작성이 되었는지 검사합니다.
      *
      * ```
-     * import java.lang.Exception
-     *
      * /**
-     *  * @description 모든 어노테이션이 존재하는 함수 예제
-     *  *
-     *  * @param ex1 테스트 용 문자열
-     *  * @param efg 테스트 용 숫자
-     *  * @return 반환값은 없습니다.
-     *  * @throws Exception
-     *  */
-     * fun fullMethod(ex1: String, efg: Int) {
-     *     throw Exception()
+     * * 모든 어노테이션이 존재하는 함수 예제
+     * *
+     * * @param ex1 테스트 용 문자열
+     * * @param efg 테스트 용 숫자
+     * * @return 무조건 0 입니다.
+     * * @throws Exception
+     * */
+     * fun fullMethod(ex1: String, efg: Int): Int {
+     *     if ("".isEmpty())
+     *         return 0
+     *     else
+     *         throw Exception()
      * }
      *
      *
@@ -111,9 +114,8 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
      *
      * 1. 함수에 KDoc 이 명시되지 않을 경우
      * 2. @param 명세 개수가, 매개 변수 개수가 일치하지 않을 경우
-     * 3. @return, @throws, @description 에 오타가 있을 경우
-     * 4. @return, @description 이 명세되지 않았을 경우 (@throws 는 필요에 따라 명세)
-     * 5. @param 가 명시되어야 할 조건인데, 명세되지 않았을 경우
+     * 3. 필수 어노테이션이 명세되지 않았을 경우
+     * 4. 필수 어노테이션에 대응하는 내용이 없을 경우
      *
      * ```
      * import java.lang.Exception
@@ -123,11 +125,9 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
      *
      *
      * /**
-     *  * @description 실패 케이스입니다.
+     *  * 실패 케이스입니다.
      *  *
-     *  * @param ex1 테스트 용 문자열
-     *  * @param efg 명세되지 않은 params
-     *  //       ~~~ <- 명세되지 않은 params
+     *  * ~~ <- param 이 명세되지 않음 (= param 어노테이션 개수와, 매개변수 개수가 일치하지 않음)
      *  * @return 반환값은 없습니다.
      *  * @throws Exception
      *  */
@@ -135,37 +135,35 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
      *
      *
      * /**
-     *  * @ddescription 실패 케이스입니다.
-     *  //~~~~~~~~~~~~~ <- 잘못 입력된 annotation
+     *  * 실패 케이스입니다.
      *  *
+     *  * @param ex1 테스트 용 문자열
+     *  * @param efg 명세되지 않은 params
+     *  //       ~~~ <- 명세되지 않은 params
      *  * @return 반환값은 없습니다.
      *  * @throws Exception
      *  */
-     * fun failed3() {
-     *     throw Exception();
-     * }
+     * fun failed3(ex1: String) { ... }
      *
      *
      * /**
-     *  * @description return 이 없는 경우입니다.
+     *  * return 이 없는 경우입니다.
      *  *
      *  * @param ex1 테스트 용 문자열
      *  * @param efg 테스트 용 숫자
      *  // ~~ <- return 이 명세되지 않음
      *  */
-     * override fun failed2(ex1: String, efg: Int) {
-     * }
+     * abstract fun failed4(ex1: String, efg: Int)
      *
      *
      * /**
-     *  * @description 일부 param(efg) 명세가 없는 경우입니다.
+     *  * 어노테이션에 대응되는 내용이 없는 경우입니다.
      *  *
-     *  * @param ex1 테스트 용 문자열
-     *  // ~~ <- param(efg) 이 명세되지 않음
+     *  * @param ex1 ~~ <- 내용이 명세되지 않음
      *  * @return 반환값은 없습니다.
      *  * @throws Exception
      *  */
-     * override fun failed2(ex1: String, efg: Int) {
+     * override fun failed5(ex1: String) {
      *     throw Exception()
      * }
      * ```
@@ -173,87 +171,83 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
 
     override fun createUastHandler(context: JavaContext) = object : UElementHandler() {
         override fun visitMethod(node: UMethod) {
-            val kDocArea = (node.sourcePsi as? KtNamedFunction)?.firstChild ?: return
-            val kDocTags = kDocArea.children
-                .filterIsInstance<KDocSection>()
-                .firstOrNull()?.children
+            val kDocArea = (node.sourcePsi as? KtNamedFunction)?.children?.firstOrNull {
+                it is KDoc
+            }
+            val kDocSections = kDocArea?.children
+                ?.filterIsInstance<KDocSection>()
+                ?.firstOrNull()?.children
 
             val bodyArea = node.sourcePsi?.lastChild as? KtBlockExpression
                 ?: node.sourcePsi?.lastChild as? KtReferenceExpression
-            val isThrowsOptional = bodyArea?.children
-                ?.none {
-                    it.node.elementType == KtNodeTypes.THROW
-                }
-                ?: true
 
             // kDoc 으로 치환될 수 있는 주석이 없다면 에러를 발생 시킨다.
-            if (!kDocTags.isNullOrEmpty()) {
-                // kDocTag 들을 분류한다.
-                // ("param" 을 name 으로 가지지 않는 kDocTags, "param" 을 name 으로 가진 kDocTags)
-                val (kDocNotParamTags, kDocParamTags) = kDocTags
-                    .mapNotNull {
-                        it as? KDocTag
-                    }
-                    .partition { kDocTag ->
-                        kDocTag.name != "param"
-                    }
+            if (kDocSections.isNullOrEmpty()) {
+                return sendErrorReport(context, node, kDoc_명세_필요)
+            }
 
-                // 반드시 존재해야 하는 Annotations
-                // ("param" 의 경우 따로 분석하며, throws 는 throws 가 있을 경우 추가해준다.)
-                val mustExistAnnotations = mutableListOf(
-                    "description",
-                    "return",
-                ).apply {
-                    if (!isThrowsOptional) add("throws")
+            // kDocTag 들을 어노테이션 이름 (name) 에 따라 분류하기
+            val kDocTags = kDocSections
+                .mapNotNull {
+                    it as? KDocTag
                 }
-
-                // "param" 을 제외한 각 KDocTag 내용에 대해 분석한다.
-                kDocNotParamTags.forEach { kDocTag ->
-                    val isDeleted = mustExistAnnotations.remove(kDocTag.name)
-
-                    if (!isDeleted)
-                        return sendErrorReport(context, node, ExplanationWrongParam1)
-                    else if (kDocTag.getContent().isBlank() || kDocTag.getContent().isEmpty()) {
-                        // TODO (riflockle7) 어노테이션 명세는 있으나, 내용 명세가 없는 경우에 대한 정책 확인 필요
-                        println("어노태이션 대응 내용 중 빈 내용 존재")
-                    }
+                .groupBy { kDocTag ->
+                    kDocTag.name
                 }
+                .toMutableMap()
 
-                // "param" 을 제외한 어노테이션이 다 명세되었는지 확인한다. ("throws" 는 조건에 따라 명세)
-                // 명세 안된 어노테이션이 있을 경우 에러를 발생 시킨다.
-                if (mustExistAnnotations.isNotEmpty())
-                    return sendErrorReport(context, node, ExplanationParamNotCompleted1)
-
-                val methodParameterNames = node.uastParameters.mapNotNull {
-                    (it.sourcePsi as? KtParameter)?.name
-                }.toMutableList()
-
-                // kDoc 에 명세된 "param" 개수와, 실제 매개변수 개수가 다르면 에러를 발생 시킨다.
-                if (kDocParamTags.size != methodParameterNames.size)
-                    return sendErrorReport(context, node, ExplanationParamCountNotEqual)
-
+            // "param" 명세가 필요한 지 체크
+            val methodParameterNames = node.uastParameters.mapNotNull {
+                (it.sourcePsi as? KtParameter)?.name
+            }.toMutableList()
+            val isParamsOptional = methodParameterNames.isEmpty()
+            // "params" 린트 검사
+            if (methodParameterNames.size != (kDocTags["param"]?.size ?: 0))
+                return sendErrorReport(context, node, param_개수와_매개변수_개수_불일치)
+            if (!isParamsOptional) {
                 // 각 "param" KDocTag 내용에 대해 분석한다.
-                kDocParamTags.forEach { kDocParameterTag ->
+                kDocTags["param"]?.forEach { kDocParameterTag ->
                     // 'variable name' 과 kDocParameterTag.getSubjectName() 이 같은지 체크한다.
                     val isDeleted = methodParameterNames.remove(kDocParameterTag.getSubjectName())
 
-                    if (!isDeleted)
-                        return sendErrorReport(context, node, ExplanationParamNotCompleted2)
-                    else if (
-                        kDocParameterTag.getContent().isBlank() ||
-                        kDocParameterTag.getContent().isEmpty()
-                    ) {
-                        // TODO (riflockle7) 어노테이션 명세는 있으나, 내용 명세가 없는 경우에 대한 정책 확인 필요
-                        println("어노태이션 대응 내용 중 빈 내용 존재")
+                    if (!isDeleted) {
+                        return sendErrorReport(context, node, param_명세_필요)
+                    } else if (kDocParameterTag.getSubjectName().isNullOrBlank()) {
+                        return sendErrorReport(context, node, annotation에_대응하는_내용_없음)
                     }
-                }
-
-                // 분석 안된 "param" 이 있을 경우 에러를 발생 시킨다.
-                if (methodParameterNames.isNotEmpty())
-                    return sendErrorReport(context, node, ExplanationParamNotCompleted2)
-            } else {
-                sendErrorReport(context, node, ExplanationKDocNotExist)
+                } ?: return sendErrorReport(context, node, param_명세_필요)
             }
+            kDocTags.remove("param")
+
+            // "throws" 명세가 필요한 지 체크
+            val isThrowsOptional = bodyArea?.children
+                ?.none { bodyElement ->
+                    bodyElement.node.elementType == KtNodeTypes.THROW
+                }
+                ?: true
+            // "throws" 린트 검사
+            if (!isThrowsOptional && kDocTags["throws"].isNullOrEmpty()) {
+                return sendErrorReport(context, node, throws_명세_필요)
+            }
+            kDocTags["throws"]?.forEach { kDocThrowsTag ->
+                if (kDocThrowsTag.getSubjectName().isNullOrBlank()) {
+                    return sendErrorReport(context, node, annotation에_대응하는_내용_없음)
+                }
+            }
+            kDocTags.remove("throws")
+
+            // "return" 명세가 필요한 지 체크
+            val isReturnOptional = node.returnType == PsiType.VOID
+            // "return" 린트 검사
+            if (!isReturnOptional && kDocTags["return"].isNullOrEmpty()) {
+                return sendErrorReport(context, node, return_명세_필요)
+            }
+            kDocTags["return"]?.forEach { kDocReturnTag ->
+                if (kDocReturnTag.getContent().isBlank()) {
+                    return sendErrorReport(context, node, annotation에_대응하는_내용_없음)
+                }
+            }
+            kDocTags.remove("return")
         }
 
         private fun sendErrorReport(

--- a/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/KDocFieldsDetector.kt
+++ b/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/KDocFieldsDetector.kt
@@ -173,6 +173,10 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
     override fun createUastHandler(context: JavaContext) = object : UElementHandler() {
         override fun visitMethod(node: UMethod) {
             val kDocArea = node.sourcePsi?.firstChild
+            val kDocTags = kDocArea?.children
+                ?.filterIsInstance<KDocSection>()
+                ?.firstOrNull()?.children
+
             // expression 형태로 처리되는 경우도 있으므로
             val blockArea = node.sourcePsi?.lastChild as? KtBlockExpression
                 ?: node.sourcePsi?.lastChild as? KtReferenceExpression
@@ -181,9 +185,7 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
                 ?: true
 
             // kDoc 으로 치환될 수 있는 주석이 없다면 에러를 발생 시킨다.
-
-            if (kDocArea != null && kDocArea.children.isNotEmpty()) {
-                val kDocTags = kDocArea.children.filterIsInstance<KDocSection>().first().children
+            if (!kDocTags.isNullOrEmpty()) {
                 // kDocTag 들을 분류한다.
                 // ("param" 을 name 으로 가지지 않는 kDocTags, "param" 을 name 으로 가진 kDocTags)
                 val (kDocNotParamTags, kDocParamTags) = kDocTags

--- a/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/KDocFieldsDetector.kt
+++ b/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/KDocFieldsDetector.kt
@@ -38,12 +38,12 @@ import org.jetbrains.uast.toUElement
 private const val BriefDescription = "함수에 KDoc 및 @param, @return, @throws 및 description 필수"
 private const val Explanation = "함수에 KDoc (/** and end with */)을 추가해야 합니다.\n" +
         "그리고 누락된 내용(@param, @return, @throws, @description) 이 없는지 체크해야 합니다."
-private const val kDoc_명세_필요 = "함수에는 KDoc 이 명시되어야 합니다."
-private const val param_개수와_매개변수_개수_불일치 = "@param 명세 개수가, 매개 변수 개수가 일치해야 합니다."
-private const val return_명세_필요 = "@return 이 반드시 명세되어야 합니다 "
-private const val throws_명세_필요 = "@throws 이 반드시 명세되어야 합니다 "
-private const val param_명세_필요 = "함수 내 모든 매개변수에 대하여, @param 는 반드시 명세되어야 합니다"
-private const val annotation에_대응하는_내용_없음 = "어노태이션에 대응하는 내용이 반드시 있어야 합니다."
+private const val KDoc_명세_필요 = "함수에는 KDoc 이 명시되어야 합니다."
+private const val Param_개수와_매개변수_개수_불일치 = "@param 명세 개수가, 매개 변수 개수가 일치해야 합니다."
+private const val Return_명세_필요 = "@return 이 반드시 명세되어야 합니다 "
+private const val Throws_명세_필요 = "@throws 이 반드시 명세되어야 합니다 "
+private const val Param_명세_필요 = "함수 내 모든 매개변수에 대하여, @param 는 반드시 명세되어야 합니다"
+private const val Annotation_에_대응하는_내용_없음 = "어노태이션에 대응하는 내용이 반드시 있어야 합니다."
 
 val KDocFieldsIssue = Issue.create(
     id = "KDocFields",
@@ -183,7 +183,7 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
 
             // kDoc 으로 치환될 수 있는 주석이 없다면 에러를 발생 시킨다.
             if (kDocSections.isNullOrEmpty()) {
-                return sendErrorReport(context, node, kDoc_명세_필요)
+                return sendErrorReport(context, node, KDoc_명세_필요)
             }
 
             // kDocTag 들을 어노테이션 이름 (name) 에 따라 분류하기
@@ -203,7 +203,7 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
             val isParamsOptional = methodParameterNames.isEmpty()
             // "params" 린트 검사
             if (methodParameterNames.size != (kDocTags["param"]?.size ?: 0))
-                return sendErrorReport(context, node, param_개수와_매개변수_개수_불일치)
+                return sendErrorReport(context, node, Param_개수와_매개변수_개수_불일치)
             if (!isParamsOptional) {
                 // 각 "param" KDocTag 내용에 대해 분석한다.
                 kDocTags["param"]?.forEach { kDocParameterTag ->
@@ -211,11 +211,11 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
                     val isDeleted = methodParameterNames.remove(kDocParameterTag.getSubjectName())
 
                     if (!isDeleted) {
-                        return sendErrorReport(context, node, param_명세_필요)
+                        return sendErrorReport(context, node, Param_명세_필요)
                     } else if (kDocParameterTag.getSubjectName().isNullOrBlank()) {
-                        return sendErrorReport(context, node, annotation에_대응하는_내용_없음)
+                        return sendErrorReport(context, node, Annotation_에_대응하는_내용_없음)
                     }
-                } ?: return sendErrorReport(context, node, param_명세_필요)
+                } ?: return sendErrorReport(context, node, Param_명세_필요)
             }
             kDocTags.remove("param")
 
@@ -227,11 +227,11 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
                 ?: true
             // "throws" 린트 검사
             if (!isThrowsOptional && kDocTags["throws"].isNullOrEmpty()) {
-                return sendErrorReport(context, node, throws_명세_필요)
+                return sendErrorReport(context, node, Throws_명세_필요)
             }
             kDocTags["throws"]?.forEach { kDocThrowsTag ->
                 if (kDocThrowsTag.getSubjectName().isNullOrBlank()) {
-                    return sendErrorReport(context, node, annotation에_대응하는_내용_없음)
+                    return sendErrorReport(context, node, Annotation_에_대응하는_내용_없음)
                 }
             }
             kDocTags.remove("throws")
@@ -240,11 +240,11 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
             val isReturnOptional = node.returnType == PsiType.VOID
             // "return" 린트 검사
             if (!isReturnOptional && kDocTags["return"].isNullOrEmpty()) {
-                return sendErrorReport(context, node, return_명세_필요)
+                return sendErrorReport(context, node, Return_명세_필요)
             }
             kDocTags["return"]?.forEach { kDocReturnTag ->
                 if (kDocReturnTag.getContent().isBlank()) {
-                    return sendErrorReport(context, node, annotation에_대응하는_내용_없음)
+                    return sendErrorReport(context, node, Annotation_에_대응하는_내용_없음)
                 }
             }
             kDocTags.remove("return")

--- a/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/KDocFieldsDetector.kt
+++ b/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/KDocFieldsDetector.kt
@@ -233,8 +233,8 @@ class KDocFieldsDetector : Detector(), SourceCodeScanner {
                     if (!isDeleted)
                         return sendErrorReport(context, node, ExplanationParamNotCompleted2)
                     else if (
-                        kDocParameterTag.getContent().isBlank()
-                        || kDocParameterTag.getContent().isEmpty()
+                        kDocParameterTag.getContent().isBlank() ||
+                        kDocParameterTag.getContent().isEmpty()
                     ) {
                         // TODO (riflockle7) 어노테이션 명세는 있으나, 내용 명세가 없는 경우에 대한 정책 확인 필요
                         println("어노태이션 대응 내용 중 빈 내용 존재")

--- a/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/KDocFieldsDetector.kt
+++ b/lint-core/src/main/kotlin/team/duckie/quackquack/lint/core/KDocFieldsDetector.kt
@@ -1,0 +1,260 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [MutableCollectionPublicDetector.kt] created by ricky_0_k on 22. 9. 2. 오전 1:51
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+@file:Suppress(
+    "UnstableApiUsage",
+    "SameParameterValue",
+)
+
+package team.duckie.quackquack.lint.core
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocSection
+import org.jetbrains.kotlin.kdoc.psi.impl.KDocTag
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.toUElement
+
+private const val BriefDescription = "함수에 KDoc 및 @param, @return, @throws 및 description 필수"
+private const val Explanation = "함수에 KDoc (/** and end with */)을 추가해야 합니다.\n" +
+        "그리고 누락된 내용(@param, @return, @throws, @description) 이 없는지 체크해야 합니다."
+private const val ExplanationKDocNotExist = "함수에는 KDoc 이 명시되어야 합니다."
+private const val ExplanationParamCountNotEqual = "@param 명세 개수가, 매개 변수 개수가 일치해야 합니다."
+private const val ExplanationWrongParam1 = "@return, @throws, @description 에 오타가 있습니다"
+private const val ExplanationParamNotCompleted1 = "@return, @description 은 반드시 명세되어야 합니다 " +
+        "(@throws 는 필요에 따라 명세)"
+private const val ExplanationParamNotCompleted2 = "함수 내 매개변수가 있을 시, @param 는 반드시 명세되어야 합니다"
+
+val KDocFieldsIssue = Issue.create(
+    id = "KDocFields",
+    briefDescription = BriefDescription,
+    explanation = Explanation,
+    category = Category.PERFORMANCE,
+    priority = 7,
+    severity = Severity.ERROR,
+    implementation = Implementation(
+        KDocFieldsDetector::class.java,
+        Scope.JAVA_FILE_SCOPE
+    )
+)
+
+class KDocFieldsDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableUastTypes() = listOf(
+        UMethod::class.java,
+    )
+    /**
+     * QuackQuack 린트의 함수에 KDoc 스타일 규칙을 구현합니다.
+     *
+     * 다음과 같은 조건에서 린트 검사를 진행합니다.
+     *
+     * 1. 함수를 사용할 시
+     *
+     * 해당 검사는 함수에 KDoc 스타일 형태 주석 작성을 권장하도록 하는 린트 검사입니다.
+     * 그러므로 함수인 경우에 KDoc 스타일로 작성이 되었는지 검사합니다.
+     *
+     * ```
+     * import java.lang.Exception
+     *
+     * /**
+     *  * @description 모든 어노테이션이 존재하는 함수 예제
+     *  *
+     *  * @param ex1 테스트 용 문자열
+     *  * @param efg 테스트 용 숫자
+     *  * @return 반환값은 없습니다.
+     *  * @throws Exception
+     *  */
+     * fun fullMethod(ex1: String, efg: Int) {
+     *     throw Exception()
+     * }
+     *
+     *
+     * /**
+     *  *
+     *  *
+     *  *
+     *  * @description 모든 어노테이션이 존재하는 함수 예제
+     *  *
+     *  * @param ex1 테스트 용 문자열
+     *  * 가나다라
+     *  *
+     *  * @param efg 테스트 용 숫자
+     *  * abcdefg
+     *  * @return 반환값은 없습니다.
+     *  * 0123461#@!%@!
+     *  * @throws Exception
+     *  */
+     * fun onlyCheckKDocSection(ex1: String, efg: Int) {
+     *     throw Exception()
+     * }
+     * ```
+     *
+     * 다음과 같은 조건에서 에러를 캐치합니다.
+     *
+     * 1. 함수에 KDoc 이 명시되지 않을 경우
+     * 2. @param 명세 개수가, 매개 변수 개수가 일치하지 않을 경우
+     * 3. @return, @throws, @description 에 오타가 있을 경우
+     * 4. @return, @description 이 명세되지 않았을 경우 (@throws 는 필요에 따라 명세)
+     * 5. @param 가 명시되어야 할 조건인데, 명세되지 않았을 경우
+     *
+     * ```
+     * import java.lang.Exception
+     *
+     * ~~~ <- KDoc 주석이 없음
+     * fun failed1(ex1: String, efg: Int) { ... }
+     *
+     *
+     * /**
+     *  * @description 실패 케이스입니다.
+     *  *
+     *  * @param ex1 테스트 용 문자열
+     *  * @param efg 명세되지 않은 params
+     *  //       ~~~ <- 명세되지 않은 params
+     *  * @return 반환값은 없습니다.
+     *  * @throws Exception
+     *  */
+     * fun failed2(ex1: String) { ... }
+     *
+     *
+     * /**
+     *  * @ddescription 실패 케이스입니다.
+     *  //~~~~~~~~~~~~~ <- 잘못 입력된 annotation
+     *  *
+     *  * @return 반환값은 없습니다.
+     *  * @throws Exception
+     *  */
+     * fun failed3() {
+     *     throw Exception();
+     * }
+     *
+     *
+     * /**
+     *  * @description return 이 없는 경우입니다.
+     *  *
+     *  * @param ex1 테스트 용 문자열
+     *  * @param efg 테스트 용 숫자
+     *  // ~~ <- return 이 명세되지 않음
+     *  */
+     * override fun failed2(ex1: String, efg: Int) {
+     * }
+     *
+     *
+     * /**
+     *  * @description 일부 param(efg) 명세가 없는 경우입니다.
+     *  *
+     *  * @param ex1 테스트 용 문자열
+     *  // ~~ <- param(efg) 이 명세되지 않음
+     *  * @return 반환값은 없습니다.
+     *  * @throws Exception
+     *  */
+     * override fun failed2(ex1: String, efg: Int) {
+     *     throw Exception()
+     * }
+     * ```
+     */
+
+    override fun createUastHandler(context: JavaContext) = object : UElementHandler() {
+        override fun visitMethod(node: UMethod) {
+            val kDocArea = node.sourcePsi?.firstChild
+            val blockArea = node.sourcePsi?.lastChild
+            val isThrowsOptional = blockArea?.children
+                ?.filter { it.node.elementType == KtNodeTypes.THROW }
+                .isNullOrEmpty()
+
+            // kDoc 으로 치환될 수 있는 주석이 없다면 에러를 발생 시킨다.
+
+            if (kDocArea != null && kDocArea.children.isNotEmpty()) {
+                val kDocTags = kDocArea.children.filterIsInstance<KDocSection>().first().children
+                // kDocTag 들을 분류한다.
+                // ("param" 을 name 으로 가지지 않는 kDocTags, "param" 을 name 으로 가진 kDocTags)
+                val (kDocNotParamTags, kDocParamTags) = kDocTags
+                    .mapNotNull {
+                        it as? KDocTag
+                    }
+                    .partition { kDocTag ->
+                        kDocTag.name != "param"
+                    }
+
+                // 반드시 존재해야 하는 Annotations
+                // ("param" 의 경우 따로 분석하며, throws 는 throws 가 있을 경우 추가해준다.)
+                val mustExistAnnotations = mutableListOf(
+                    "description",
+                    "return",
+                ).apply { if (!isThrowsOptional) add("throws") }
+
+                // "param" 을 제외한 각 KDocTag 내용에 대해 분석한다.
+                kDocNotParamTags.forEach { kDocTag ->
+                    val isDeleted = mustExistAnnotations.remove(kDocTag.name)
+
+                    if (!isDeleted)
+                        return sendErrorReport(context, node, ExplanationWrongParam1)
+                    else if (kDocTag.getContent().isBlank() || kDocTag.getContent().isEmpty()) {
+                        // TODO (riflockle7) 어노테이션 명세는 있으나, 내용 명세가 없는 경우에 대한 정책 확인 필요
+                        println("어노태이션 대응 내용 중 빈 내용 존재")
+                    }
+                }
+
+                // "param" 을 제외한 어노테이션이 다 명세되었는지 확인한다. ("throws" 는 조건에 따라 명세)
+                // 명세 안된 어노테이션이 있을 경우 에러를 발생 시킨다.
+                if (mustExistAnnotations.isNotEmpty())
+                    return sendErrorReport(context, node, ExplanationParamNotCompleted1)
+
+                val methodParameterNames = node.uastParameters
+                    .mapNotNull { (it.sourcePsi as? KtParameter)?.name }.toMutableList()
+
+                // kDoc 에 명세된 "param" 개수와, 실제 매개변수 개수가 다르면 에러를 발생 시킨다.
+                if (kDocParamTags.size != methodParameterNames.size)
+                    return sendErrorReport(context, node, ExplanationParamCountNotEqual)
+
+                // 각 "param" KDocTag 내용에 대해 분석한다.
+                kDocParamTags.forEach { kDocParameterTag ->
+                    // 'variable name' 과 kDocParameterTag.getSubjectName() 이 같은지 체크한다.
+                    val isDeleted = methodParameterNames.remove(kDocParameterTag.getSubjectName())
+
+                    if (!isDeleted)
+                        return sendErrorReport(context, node, ExplanationParamNotCompleted2)
+                    else if (
+                        kDocParameterTag.getContent().isBlank()
+                        || kDocParameterTag.getContent().isEmpty()
+                    ) {
+                        // TODO (riflockle7) 어노테이션 명세는 있으나, 내용 명세가 없는 경우에 대한 정책 확인 필요
+                        println("어노태이션 대응 내용 중 빈 내용 존재")
+                    }
+                }
+
+                // 분석 안된 "param" 이 있을 경우 에러를 발생 시킨다.
+                if (methodParameterNames.isNotEmpty())
+                    return sendErrorReport(context, node, ExplanationParamNotCompleted2)
+            } else {
+                sendErrorReport(context, node, ExplanationKDocNotExist)
+            }
+        }
+
+        private fun sendErrorReport(
+            context: JavaContext,
+            node: UMethod,
+            message: String,
+        ) {
+            context.report(
+                issue = KDocFieldsIssue,
+                scope = node.toUElement(),
+                location = context.getNameLocation(node),
+                message = message,
+            )
+        }
+    }
+}

--- a/lint-core/src/test/kotlin/team/duckie/quackquack/lint/core/KDocFieldsTest.kt
+++ b/lint-core/src/test/kotlin/team/duckie/quackquack/lint/core/KDocFieldsTest.kt
@@ -232,7 +232,7 @@ class KDocFieldsTest {
     }
 
     @Test
-    fun `require annotations must be specified`() {
+    fun `require annotations must be specified (success)`() {
         lintTestRule.assertErrorCount(
             files = listOf(
                 composableTestFile(
@@ -240,7 +240,7 @@ class KDocFieldsTest {
                         import java.lang.Exception
 
                         /**
-                         * @ddescription ddescription 오타가 있지만 필수 어노테이션이 아니므로 성공합니다.
+                         * @ddescription 오타가 있지만, 필수 어노테이션이 아니므로 성공합니다.
                          *
                          * @return 반환값은 없습니다.
                          * @throws Exception
@@ -250,7 +250,7 @@ class KDocFieldsTest {
                         }
 
                         /**
-                         * description 이 없는 경우입니다. 필수 어노테이션이 아니므로 성공합니다.
+                         * description 이 없지만, 필수 어노테이션이 아니므로 성공합니다.
                          *
                          * @param ex1 테스트 용 문자열
                          * @param efg 테스트 용 숫자
@@ -262,16 +262,31 @@ class KDocFieldsTest {
                         }
 
                         /**
-                         * @description return 이 없는 경우입니다. 반환값이 없어 필수 어노테이션이 아니므로 성공합니다.
+                         * return 이 없지만, 반환값이 없어 필수 어노테이션이 아니므로 성공합니다.
                          *
                          * @param ex1 테스트 용 문자열
                          * @param efg 테스트 용 숫자
                          */
                         override fun success3(ex1: String, efg: Int) {
                         }
+                        """
+                ),
+            ),
+            issues = listOf(
+                KDocFieldsIssue,
+            ),
+            expectedCount = 0,
+        )
+    }
 
+    @Test
+    fun `require annotations must be specified (fail)`() {
+        lintTestRule.assertErrorCount(
+            files = listOf(
+                composableTestFile(
+                    """
                         /**
-                         * @description return 명시가 제대로 되어있지 않아 실패합니다.
+                         * @description return 이 필요하지만, 오타가 있으므로 실패합니다.
                          *
                          * @rreturn 빈 리스트를 반환합니다.
                          * @throws Exception
@@ -285,7 +300,7 @@ class KDocFieldsTest {
                         }
 
                         /**
-                         * @description throws 명시가 제대로 되어있지 않아 실패합니다.
+                         * throws 가 필요하지만, 오타가 있으므로 실패합니다.
                          *
                          * @return 반환값은 없습니다.
                          * @tthrows Exception
@@ -295,7 +310,7 @@ class KDocFieldsTest {
                         }
 
                         /**
-                         * @description @throws 가 없는 경우입니다. throw 코드가 있어 필수 어노테이션이므로 실패합니다.
+                         * throw 코드가 있어 필수 어노테이션이지만, 명세가 없어 실패합니다.
                          *
                          * @param ex1 테스트 용 문자열
                          * @param efg 테스트 용 숫자
@@ -305,7 +320,7 @@ class KDocFieldsTest {
                         }
 
                         /**
-                         * @description param(ex1, efg) 명세가 없는 경우입니다.
+                         * @description param(ex1, efg) 명세가 없어 실패합니다.
                          *
                          * @return 반환값은 없습니다.
                          * @throws Exception
@@ -315,7 +330,7 @@ class KDocFieldsTest {
                         }
 
                         /**
-                         * @description 일부 param(efg) 명세가 없는 경우입니다.
+                         * @description 일부 param(efg) 명세가 없어 실패합니다.
                          *
                          * @param ex1 테스트 용 문자열
                          * @return 반환값은 없습니다.
@@ -326,7 +341,7 @@ class KDocFieldsTest {
                         }
 
                         /**
-                         * @description 일부 param(efg) 명세에 오타가 있는 경우입니다.
+                         * @description 일부 param(ex2) 에 오타가 있어 실패합니다.
                          *
                          * @param ex2 테스트 용 문자열
                          * @param efg 테스트 용 숫자

--- a/lint-core/src/test/kotlin/team/duckie/quackquack/lint/core/KDocFieldsTest.kt
+++ b/lint-core/src/test/kotlin/team/duckie/quackquack/lint/core/KDocFieldsTest.kt
@@ -1,0 +1,344 @@
+/*
+ * Designed and developed by 2022 SungbinLand, Team Duckie
+ *
+ * [KDocFieldsTest.kt] created by ricky_0_k on 22. 9. 2. 오전 2:07
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/sungbinland/quack-quack/blob/main/LICENSE
+ */
+
+package team.duckie.quackquack.lint.core
+
+import org.junit.Rule
+import org.junit.Test
+import team.duckie.quackquack.common.lint.test.LintTestRule
+import team.duckie.quackquack.common.lint.test.composableTestFile
+
+/**
+ * 테스트 성공 조건
+ * 1. 정상적인 케이스
+ * 2. 오직 KDocSection 에 대해서만 체크해야 합니다. (공백 등은 체크하지 않음)
+ * 3. 함수에는 KDoc 이 명시되어야 합니다.
+ * 4. @param 명세 개수가, 매개 변수 개수가 일치해야 합니다.
+ * 5. @return, @throws, @description 에 오타가 없어야 합니다.
+ * 6. @return, @description 은 반드시 명세되어야 합니다. (@throws 는 필요에 따라 명세되어야 합니다.)
+ * 7. 함수 내 매개변수가 있을 시, @param 는 반드시 명세되어야 합니다
+ */
+class KDocFieldsTest {
+
+    @get:Rule
+    val lintTestRule = LintTestRule()
+
+    @Test
+    fun `Great Function KDoc Case`() {
+        lintTestRule.assertErrorCount(
+            files = listOf(
+                composableTestFile(
+                    """
+                        import java.lang.Exception
+
+                        /**
+                         * @description 모든 어노테이션이 존재하는 함수 예제
+                         *
+                         * @param ex1 테스트 용 문자열
+                         * @param efg 테스트 용 숫자
+                         * @return 반환값은 없습니다.
+                         * @throws Exception
+                         */
+                        fun `All annotations exist function Example`(ex1: String, efg: Int) {
+                            throw Exception()
+                        }
+
+                        /**
+                         * @description "params" 어노테이션이 없는 함수 예제
+                         *
+                         * @return 반환값은 없습니다.
+                         * @throws Exception
+                         */
+                        fun `None parameter function Example`() {
+                            throw Exception()
+                        }
+
+                        /**
+                         * @description 예외를 방출하지 않는 함수 예제
+                         *
+                         * @return 반환값은 없습니다.
+                         */
+                        fun `Not Emit throw Exception function Example`() {
+                        }
+                        """
+                ),
+            ),
+            issues = listOf(
+                KDocFieldsIssue,
+            ),
+            expectedCount = 0,
+        )
+    }
+
+    @Test
+    fun `Only Check KDocSection`() {
+        lintTestRule.assertErrorCount(
+            files = listOf(
+                composableTestFile(
+                    """
+                        import java.lang.Exception
+
+                        /**
+                         *
+                         *
+                         *
+                         * @description 모든 어노테이션이 존재하는 함수 예제
+                         *
+                         * @param ex1 테스트 용 문자열
+                         * 가나다라
+                         *
+                         * @param efg 테스트 용 숫자
+                         * abcdefg
+                         * @return 반환값은 없습니다.
+                         * 0123461#@!%@!
+                         * @throws Exception
+                         */
+                        fun `All annotations exist function Example`(ex1: String, efg: Int) {
+                            throw Exception()
+                        }
+
+                        /**
+                         * @description "params" 어노테이션이 없는 함수 예제
+                         *
+                         * @return 반환값은 없습니다.
+                         * abcdefg
+                         * 궭뉅
+                         * @throws Exception
+                         */
+                        fun `None parameter function Example`() {
+                            throw Exception()
+                        }
+
+                        /**
+                         *
+                         * a
+                         *
+                         * b
+                         * @description 예외를 방출하지 않는 함수 예제
+                         *
+                         * @return 반환값은 없습니다.
+                         */
+                        fun `Not Emit throw Exception function Example`() {
+                        }
+                        """
+                ),
+            ),
+            issues = listOf(
+                KDocFieldsIssue,
+            ),
+            expectedCount = 0,
+        )
+    }
+
+    @Test
+    fun `Function must have a KDoc specified`() {
+        lintTestRule.assertErrorCount(
+            files = listOf(
+                composableTestFile(
+                    """
+                        import java.lang.Exception
+
+                        fun kDocNotExist() {
+                            throw Exception();
+                        }
+                        """
+                ),
+            ),
+            issues = listOf(
+                KDocFieldsIssue,
+            ),
+            expectedCount = 1,
+        )
+    }
+
+    @Test
+    fun `the number @param's and the number of parameters must match`() {
+        lintTestRule.assertErrorCount(
+            files = listOf(
+                composableTestFile(
+                    """
+                        import java.lang.Exception
+
+                        /**
+                         * @description 실패 케이스입니다.
+                         *
+                         * @param ex1 테스트 용 문자열
+                         * @param efg 명세되지 않은 params
+                         * @return 반환값은 없습니다.
+                         * @throws Exception
+                         */
+                        fun failed1(ex1: String) {
+                            throw Exception();
+                        }
+
+                        /**
+                         * @description 실패 케이스입니다.
+                         *
+                         * @param efg 명세되지 않은 params
+                         * @return 반환값은 없습니다.
+                         * @throws Exception
+                         */
+                        fun failed2() {
+                            throw Exception();
+                        }
+                        """
+                ),
+            ),
+            issues = listOf(
+                KDocFieldsIssue,
+            ),
+            expectedCount = 2,
+        )
+    }
+
+    @Test
+    fun `@return, @throws, @description must not contain invalid inputs`() {
+        lintTestRule.assertErrorCount(
+            files = listOf(
+                composableTestFile(
+                    """
+                        import java.lang.Exception
+
+                        /**
+                         * @ddescription 실패 케이스입니다.
+                         *
+                         * @return 반환값은 없습니다.
+                         * @throws Exception
+                         */
+                        fun failed1() {
+                            throw Exception();
+                        }
+
+                        /**
+                         * @description 실패 케이스입니다.
+                         *
+                         * @rreturn 반환값은 없습니다.
+                         * @throws Exception
+                         */
+                        fun failed2() {
+                            throw Exception();
+                        }
+
+                        /**
+                         * @description 실패 케이스입니다.
+                         *
+                         * @return 반환값은 없습니다.
+                         * @tthrows Exception
+                         */
+                        fun failed3() {
+                            throw Exception();
+                        }
+                        """
+                ),
+            ),
+            issues = listOf(
+                KDocFieldsIssue,
+            ),
+            expectedCount = 3,
+        )
+    }
+
+    @Test
+    fun `@return, @description must be specified (@throws is Optional)`() {
+        lintTestRule.assertErrorCount(
+            files = listOf(
+                composableTestFile(
+                    """
+                        import java.lang.Exception
+
+                        /**
+                         * description 이 없는 경우입니다.
+                         *
+                         * @param ex1 테스트 용 문자열
+                         * @param efg 테스트 용 숫자
+                         * @return 반환값은 없습니다.
+                         * @throws Exception
+                         */
+                        override fun failed1(ex1: String, efg: Int) {
+                            throw Exception()
+                        }
+
+                        /**
+                         * @description return 이 없는 경우입니다.
+                         *
+                         * @param ex1 테스트 용 문자열
+                         * @param efg 테스트 용 숫자
+                         */
+                        override fun failed2(ex1: String, efg: Int) {
+                        }
+
+                        /**
+                         * @description @throws 가 없는 경우입니다.
+                         *
+                         * @param ex1 테스트 용 문자열
+                         * @param efg 테스트 용 숫자
+                         */
+                        override fun failed3(ex1: String, efg: Int) {
+                            throw Exception()
+                        }
+                        """
+                ),
+            ),
+            issues = listOf(
+                KDocFieldsIssue,
+            ),
+            expectedCount = 3,
+        )
+    }
+
+    @Test
+    fun `When there are parameters in a function, @param must be specified`() {
+        lintTestRule.assertErrorCount(
+            files = listOf(
+                composableTestFile(
+                    """
+                        import java.lang.Exception
+
+                        /**
+                         * @description param(ex1, efg) 명세가 없는 경우입니다.
+                         *
+                         * @return 반환값은 없습니다.
+                         * @throws Exception
+                         */
+                        override fun failed1(ex1: String, efg: Int) {
+                            throw Exception()
+                        }
+
+                        /**
+                         * @description 일부 param(efg) 명세가 없는 경우입니다.
+                         *
+                         * @param ex1 테스트 용 문자열
+                         * @return 반환값은 없습니다.
+                         * @throws Exception
+                         */
+                        override fun failed2(ex1: String, efg: Int) {
+                            throw Exception()
+                        }
+
+                        /**
+                         * @description 일부 param(efg) 명세에 오타가 있는 경우입니다.
+                         *
+                         * @param ex2 테스트 용 문자열
+                         * @param efg 테스트 용 숫자
+                         * @return 반환값은 없습니다.
+                         * @throws Exception
+                         */
+                        override fun failed2(ex1: String, efg: Int) {
+                            throw Exception()
+                        }
+                        """
+                ),
+            ),
+            issues = listOf(
+                KDocFieldsIssue,
+            ),
+            expectedCount = 3,
+        )
+    }
+}

--- a/lint-core/src/test/kotlin/team/duckie/quackquack/lint/core/KDocFieldsTest.kt
+++ b/lint-core/src/test/kotlin/team/duckie/quackquack/lint/core/KDocFieldsTest.kt
@@ -50,14 +50,39 @@ class KDocFieldsTest {
                         }
 
                         /**
-                         * @description "params" 어노테이션이 없는 함수 예제
+                         * @description 즉시 반환형인 함수
                          *
+                         * @param ex1 테스트 용 문자열
+                         * @param efg 테스트 용 숫자
                          * @return 반환값은 없습니다.
                          * @throws Exception
                          */
-                        fun `None parameter function Example`() {
+                        fun `Reference_Expression Example`(ex1: String, efg: Int) {
                             throw Exception()
                         }
+
+                        /**
+                         * @description Composable 함수
+                         *
+                         * @return 반환값은 없습니다.
+                         * @param list 테스트 용 리스트
+                         * @throws Exception
+                         */
+                        @Composable
+                        operator fun `Compose Function With Block Example`(list: MutableList<Any>) {
+                            throw Exception()
+                        }
+
+                        /**
+                         * @description 즉시 반환 형인 Composable 함수
+                         *
+                         * @return 반환값은 없습니다.
+                         * @param list 테스트 용 리스트
+                         */
+                        @Composable
+                        operator fun `Compose Function With Reference_Expression Example`(
+                            list: MutableList<Any>
+                        ) = list
 
                         /**
                          * @description 예외를 방출하지 않는 함수 예제
@@ -66,6 +91,13 @@ class KDocFieldsTest {
                          */
                         fun `Not Emit throw Exception function Example`() {
                         }
+
+                        /**
+                         * @description 추상 함수 예제
+                         *
+                         * @return 반환값은 없습니다.
+                         */
+                        abstract fun `abstract function Example`()
                         """
                 ),
             ),


### PR DESCRIPTION
## What's new?

KDocField 에 대한 Issue 및 테스트 케이스를 작성했습니다.

## 참고
1. TODO : 어노테이션은 명세했지만 내용이 비어져 있을 경우, 어떻게 처리할 것인지 정해야 합니다.
   ```kotlin
   /**
    * @description 모든 어노테이션이 존재하는 함수 예제
    *
    * @param ex1 
    * @param efg 
    * @return 
    * @throws 
    */
   fun `All annotations exist function Example`(ex1: String, efg: Int) {
       throw Exception()
   }
   ```
   에러로 칠 경우 TODO 내용에 `report()` 구문 추가 및 주석 수정이 필요하므로, 해당 내용에 대해 comment 부탁드립니다.
   그냥 무시한다고 하더라도 TODO 내용 및 해당 조건문을 지워야 하므로 한 번의 commit 이 더 필요합니다.

2. 의외로 변수가 많을 것 같은 린트여서 놓친 내용도 있을 것 같습니다. 혹시 있다면 말씀해주세요!
3. 온갖 다양하게 디테일한 에러케이스가 많아 여러 타입의 `Explanation` 문자열을 두었고, `report()` 로직을 함수화 하였습니다.
    이에 대해서도 의견 부탁드립니다.
4. 이번 작업에서 `PsiViewer` 을 적극 사용해봤는데 이거 아니었으면 작업 못할 뻔 했네요. 꼭 사용하는 걸 추천드립니다.

## 체크 리스트

- [x] Reviewer 과 Assignees 를 확인했습니다.
- [x] label 을 확인했습니다
