### PR TITLE
QuackTextField 구현 재시도

### DIFF
--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/MainActivity.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/MainActivity.kt
@@ -11,12 +11,20 @@ package team.duckie.quackquack.playground
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.first
 import team.duckie.quackquack.playground.base.BaseActivity
 import team.duckie.quackquack.playground.base.PlaygroundActivities
 import team.duckie.quackquack.playground.realworld.ButtonPlayground
+import team.duckie.quackquack.playground.realworld.QuackBasicTextFieldWithAllDecorationDemo
 import team.duckie.quackquack.playground.realworld.TabPlayground
 import team.duckie.quackquack.playground.realworld.TextFieldPlayground
 import team.duckie.quackquack.playground.theme.PlaygroundTheme
@@ -25,34 +33,53 @@ import team.duckie.quackquack.playground.util.dataStore
 import team.duckie.quackquack.ui.animation.QuackAnimationMillis
 import team.duckie.quackquack.ui.textstyle.QuackFontScale
 
-class MainActivity : BaseActivity() {
-    private val playgroundActivities = persistentListOf(
-        TabPlayground::class,
-        ButtonPlayground::class,
-        TextFieldPlayground::class,
-    )
+private val playgroundActivities = persistentListOf(
+    TabPlayground::class,
+    ButtonPlayground::class,
+    TextFieldPlayground::class,
+)
 
+class MainActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            LaunchedEffect(
-                key1 = Unit,
-            ) {
-                applicationContext.dataStore.data.first().let { preference ->
-                    QuackAnimationMillis = (
-                            preference[PreferenceConfigs.AnimationDurationKey]
-                                ?: QuackAnimationMillis
-                            ).coerceAtLeast(minimumValue = 0)
-                    QuackFontScale = (
-                            preference[PreferenceConfigs.FontScaleKey] ?: QuackFontScale
-                            ).coerceAtLeast(minimumValue = 0.0)
-                }
-            }
-            PlaygroundTheme {
-                PlaygroundActivities(
-                    activities = playgroundActivities,
-                )
+            SingleDemo {
+                QuackBasicTextFieldWithAllDecorationDemo()
             }
         }
+    }
+}
+
+@Composable
+private fun SingleDemo(
+    content: @Composable BoxScope.() -> Unit,
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+        content = content,
+    )
+}
+
+@Composable
+private fun PlaygroundDemo() {
+    val context = LocalContext.current.applicationContext
+    LaunchedEffect(
+        key1 = Unit,
+    ) {
+        context.dataStore.data.first().let { preference ->
+            QuackAnimationMillis = (
+                    preference[PreferenceConfigs.AnimationDurationKey]
+                        ?: QuackAnimationMillis
+                    ).coerceAtLeast(minimumValue = 0)
+            QuackFontScale = (
+                    preference[PreferenceConfigs.FontScaleKey] ?: QuackFontScale
+                    ).coerceAtLeast(minimumValue = 0.0)
+        }
+    }
+    PlaygroundTheme {
+        PlaygroundActivities(
+            activities = playgroundActivities,
+        )
     }
 }

--- a/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TextFieldPlayground.kt
+++ b/playground/src/main/kotlin/team/duckie/quackquack/playground/realworld/TextFieldPlayground.kt
@@ -109,7 +109,7 @@ fun QuackBasicTextFieldWithTrailingDecorationDemo() {
 fun QuackBasicTextFieldWithAllDecorationDemo() {
     var fieldState by remember {
         mutableStateOf(
-            value = "QuackBasicTextFieldDemo",
+            value = "",
         )
     }
     QuackBasicTextField(

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
@@ -14,8 +14,8 @@ package team.duckie.quackquack.ui.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -243,7 +243,7 @@ fun QuackBasicTextField(
                 height = height,
             )*/
             .fillMaxWidth()
-            .wrapContentHeight()
+            .height(100.dp)
             .background(color = Color.Red)
             .onPlaced { layoutCoordinates ->
                 with(density) {

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
@@ -12,13 +12,10 @@
 package team.duckie.quackquack.ui.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -241,23 +238,24 @@ fun QuackBasicTextField(
 
     BasicTextField(
         modifier = modifier
+            /*.applyQuackSize(
+                width = width,
+                height = height,
+            )*/
             .fillMaxWidth()
-            .height(100.dp)
+            .wrapContentHeight()
             .background(color = Color.Red)
             .onPlaced { layoutCoordinates ->
                 with(density) {
                     println("onPlaced: ${layoutCoordinates.size}")
                     println("onPlacedHeight with Dp: ${layoutCoordinates.size.height.toDp()}")
-                    // size 에서 height 가 0으로 나옴
                     textFieldSize = layoutCoordinates.size
-                    // 1440 x 1050 ????!?!?!
-                    // 사이즈가 이상하게 나오는 버그가 있음
                 }
             },
         value = text,
         onValueChange = onTextChanged,
         // TextField 는 애니메이션 적용 X
-        textStyle = textStyle.change(textAlign = TextAlign.Center).asComposeStyle(),
+        textStyle = textStyle.change(textAlign = TextAlign.Start).asComposeStyle(),
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
         singleLine = true,
@@ -333,19 +331,14 @@ private inline fun QuackTextFieldDecorationBox(
                     leadingContent()
                 }
             }
-            Column(
+            Box(
                 modifier = Modifier.layoutId(
                     layoutId = QuackTextFieldLayoutId,
                 ),
-                verticalArrangement = Arrangement.Center,
+                contentAlignment = Alignment.Center,
+                propagateMinConstraints = true,
             ) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                    propagateMinConstraints = true,
-                ) {
-                    textField()
-                }
+                textField()
             }
             if (trailingContent != null) {
                 Box(
@@ -453,6 +446,7 @@ private inline fun QuackTextFieldDecorationBox(
             val textFieldStartOffset = leadingContentPlaceable?.width?.plus(
                 other = decorationItemGap,
             ) ?: 0
+            val textFieldYOffset = textFieldSize.height / 2 - textFieldPlaceable.height / 2
 
             leadingContentPlaceable?.place(
                 x = 0,
@@ -462,7 +456,7 @@ private inline fun QuackTextFieldDecorationBox(
                 x = textFieldStartOffset.also {
                     println("textFieldStartOffset: $it")
                 },
-                y = 0,
+                y = textFieldYOffset,
             )
             trailingContentPlaceable?.place(
                 x = (textFieldSize.width - trailingContentPlaceable.width).also {

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
@@ -236,12 +236,16 @@ fun QuackBasicTextField(
         modifier = modifier
             .applyQuackSize(
                 width = width,
-                height = height,
+                height = QuackHeight.Custom(
+                    height = 300.dp,
+                ),
             )
             .onPlaced { layoutCoordinates ->
                 println("onPlaced: ${layoutCoordinates.size}")
                 // size 에서 height 가 0으로 나옴
                 textFieldSize = layoutCoordinates.size
+                // 1440 x 1050 ????!?!?!
+                // 사이즈가 이상하게 나오는 버그가 있음
             },
         value = text,
         onValueChange = onTextChanged,

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
@@ -13,13 +13,14 @@ package team.duckie.quackquack.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NoLiveLiterals
-import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,13 +34,13 @@ import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import team.duckie.quackquack.common.npe
 import team.duckie.quackquack.ui.constant.QuackHeight
 import team.duckie.quackquack.ui.constant.QuackWidth
-import team.duckie.quackquack.ui.modifier.applyQuackSize
 import team.duckie.quackquack.ui.textstyle.QuackTextStyle
 
 // /**
@@ -214,7 +215,6 @@ private val QuackTextFieldDecorationContentHorizontalPadding = 8.dp
 // }
 
 @Composable
-@NonRestartableComposable
 fun QuackBasicTextField(
     modifier: Modifier = Modifier,
     text: String,
@@ -238,12 +238,8 @@ fun QuackBasicTextField(
 
     BasicTextField(
         modifier = modifier
-            .applyQuackSize(
-                width = width,
-                height = QuackHeight.Custom(
-                    height = 100.dp,
-                ),
-            )
+            .fillMaxWidth()
+            .height(100.dp)
             .background(color = Color.Red)
             .onPlaced { layoutCoordinates ->
                 with(density) {
@@ -258,7 +254,7 @@ fun QuackBasicTextField(
         value = text,
         onValueChange = onTextChanged,
         // TextField 는 애니메이션 적용 X
-        textStyle = textStyle.asComposeStyle(),
+        textStyle = textStyle.change(textAlign = TextAlign.Center).asComposeStyle(),
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
         singleLine = true,
@@ -286,11 +282,11 @@ private fun Placeable.toDebugString() =
     "$width x $height / measured: $measuredWidth x $measuredHeight"
 
 @Composable
-private fun QuackTextFieldDecorationBox(
+private inline fun QuackTextFieldDecorationBox(
     textFieldSize: IntSize,
     textField: @Composable () -> Unit,
-    leadingContent: @Composable (() -> Unit)?,
-    trailingContent: @Composable (() -> Unit)?,
+    noinline leadingContent: @Composable (() -> Unit)?,
+    noinline trailingContent: @Composable (() -> Unit)?,
 ) {
     println("textFieldSize: $textFieldSize")
     val density = LocalDensity.current
@@ -329,6 +325,7 @@ private fun QuackTextFieldDecorationBox(
                         layoutId = QuackTextFieldLeadingContentLayoutId,
                     ),
                     contentAlignment = Alignment.Center,
+                    propagateMinConstraints = true,
                 ) {
                     leadingContent()
                 }
@@ -338,7 +335,8 @@ private fun QuackTextFieldDecorationBox(
                 modifier = Modifier.layoutId(
                     layoutId = QuackTextFieldLayoutId,
                 ),
-                contentAlignment = Alignment.TopStart,
+                contentAlignment = Alignment.BottomCenter,
+                propagateMinConstraints = true,
             ) {
                 textField()
             }
@@ -348,6 +346,7 @@ private fun QuackTextFieldDecorationBox(
                         layoutId = QuackTextFieldTrailingContentLayoutId,
                     ),
                     contentAlignment = Alignment.Center,
+                    propagateMinConstraints = true,
                 ) {
                     trailingContent()
                 }
@@ -412,7 +411,16 @@ private fun QuackTextFieldDecorationBox(
                     if (trailingContentPlaceable != null) {
                         width -= trailingContentPlaceable.width + decorationItemGap
                     }
-                    width
+                    width.also {
+                        println(
+                            """
+                            ::: textFieldPlaceable debug :::
+                            textFieldSize width: ${textFieldSize.width}
+                            calc width int: $it
+                            calc with dp: ${it.toDp()}
+                            """.trimIndent()
+                        )
+                    }
                 }.coerceAtLeast(
                     minimumValue = 0,
                 ),

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
@@ -12,7 +12,10 @@
 package team.duckie.quackquack.ui.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
@@ -330,15 +333,19 @@ private inline fun QuackTextFieldDecorationBox(
                     leadingContent()
                 }
             }
-            Box(
-                // width 는 measure 하면서 지정
+            Column(
                 modifier = Modifier.layoutId(
                     layoutId = QuackTextFieldLayoutId,
                 ),
-                contentAlignment = Alignment.BottomCenter,
-                propagateMinConstraints = true,
+                verticalArrangement = Arrangement.Center,
             ) {
-                textField()
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                    propagateMinConstraints = true,
+                ) {
+                    textField()
+                }
             }
             if (trailingContent != null) {
                 Box(
@@ -389,11 +396,32 @@ private inline fun QuackTextFieldDecorationBox(
             println("trailingContentPlaceable: ${it.toDebugString()}")
         }
 
+        val textFieldWidth = textFieldSize.width.let { _width ->
+            var width = _width
+            if (leadingContentPlaceable != null) {
+                width -= leadingContentPlaceable.width + decorationItemGap
+            }
+            if (trailingContentPlaceable != null) {
+                width -= trailingContentPlaceable.width + decorationItemGap
+            }
+            width.also {
+                println(
+                    """
+                            ::: textFieldPlaceable debug :::
+                            textFieldSize width: ${textFieldSize.width}
+                            calc width int: $it
+                            calc with dp: ${it.toDp()}
+                            """.trimIndent()
+                )
+            }
+        }.coerceAtLeast(
+            minimumValue = 0,
+        )
         // TextField
         val textFieldPlaceable = measurables.find { measurable ->
             measurable.layoutId == QuackTextFieldLayoutId
         }?.measure(
-            constraints = Constraints.fixed(
+            constraints = Constraints(
                 // TextField 의 가로 길이는 기본적으로 decoration 아이템들의 가로 길이를
                 // 포함하고 있음. 만약 decoration 아이템이 존재한다면 TextField 의
                 // 가로 길이를 decoration 아이템의 가로 길이만큼 줄여야 함.
@@ -403,28 +431,10 @@ private inline fun QuackTextFieldDecorationBox(
 
                 // FIXED: 지금은 width 가 매번 텍스트가 입력될 때마다 유동적으로 텍스트 길이에 맞게
                 // 변하고 있음. decoration item 사이로 match_content 가 되게 고정해야 함.
-                width = textFieldSize.width.let { _width ->
-                    var width = _width
-                    if (leadingContentPlaceable != null) {
-                        width -= leadingContentPlaceable.width + decorationItemGap
-                    }
-                    if (trailingContentPlaceable != null) {
-                        width -= trailingContentPlaceable.width + decorationItemGap
-                    }
-                    width.also {
-                        println(
-                            """
-                            ::: textFieldPlaceable debug :::
-                            textFieldSize width: ${textFieldSize.width}
-                            calc width int: $it
-                            calc with dp: ${it.toDp()}
-                            """.trimIndent()
-                        )
-                    }
-                }.coerceAtLeast(
-                    minimumValue = 0,
-                ),
-                height = decorationItemConstraints.minHeight,
+                minWidth = textFieldWidth,
+                maxWidth = textFieldWidth,
+                minHeight = 0,
+                maxHeight = textFieldSize.height,
             )
         )?.also {
             println("textFieldPlaceable: ${it.toDebugString()}")

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/textfield.kt
@@ -241,7 +241,7 @@ fun QuackBasicTextField(
             .applyQuackSize(
                 width = width,
                 height = QuackHeight.Custom(
-                    height = 300.dp,
+                    height = 100.dp,
                 ),
             )
             .background(color = Color.Red)
@@ -338,7 +338,7 @@ private fun QuackTextFieldDecorationBox(
                 modifier = Modifier.layoutId(
                     layoutId = QuackTextFieldLayoutId,
                 ),
-                contentAlignment = Alignment.CenterStart,
+                contentAlignment = Alignment.TopStart,
             ) {
                 textField()
             }
@@ -357,14 +357,21 @@ private fun QuackTextFieldDecorationBox(
         // decoration items 들은 height 는 TextField 와 일치해야 하고,
         // width 는 wrap_content 여야 함. 단, 최소 TextField 의 height 와는 같아야 함.
         // TODO: wrapContentWidth() 를 구현해야 함..
-        val decorationItemConstraints = Constraints(
+        /*val decorationItemConstraints = Constraints(
             minWidth = textFieldSize.height,
             maxWidth = Int.MAX_VALUE,
             minHeight = textFieldSize.height,
             maxHeight = textFieldSize.height,
         ).also {
             println("constraints: $it")
+        }*/
+        val decorationItemConstraints = Constraints.fixed(
+            width = textFieldSize.height,
+            height = textFieldSize.height,
+        ).also {
+            println("constraints: $it")
         }
+
         // leading content
         val leadingContentPlaceable = measurables.find { measurable ->
             measurable.layoutId == QuackTextFieldLeadingContentLayoutId
@@ -394,7 +401,10 @@ private fun QuackTextFieldDecorationBox(
                 // 따라서 TextField 의 가로 길이에서 decoration 아이템의 가로 길이와
                 // TextField 와 decoration 아이템 사이에 들어갈 간격 만큼 제외한 값으로
                 // TextField 의 가로 길이로 설정함.
-                width = decorationItemConstraints.minWidth.let { _width ->
+
+                // FIXED: 지금은 width 가 매번 텍스트가 입력될 때마다 유동적으로 텍스트 길이에 맞게
+                // 변하고 있음. decoration item 사이로 match_content 가 되게 고정해야 함.
+                width = textFieldSize.width.let { _width ->
                     var width = _width
                     if (leadingContentPlaceable != null) {
                         width -= leadingContentPlaceable.width + decorationItemGap
@@ -419,8 +429,8 @@ private fun QuackTextFieldDecorationBox(
         )
 
         layout(
-            width = decorationItemConstraints.minWidth,
-            height = decorationItemConstraints.minHeight,
+            width = textFieldSize.width,
+            height = textFieldSize.height,
         ) {
             val textFieldStartOffset = leadingContentPlaceable?.width?.plus(
                 other = decorationItemGap,
@@ -437,7 +447,7 @@ private fun QuackTextFieldDecorationBox(
                 y = 0,
             )
             trailingContentPlaceable?.place(
-                x = (decorationItemConstraints.minWidth - trailingContentPlaceable.width).also {
+                x = (textFieldSize.width - trailingContentPlaceable.width).also {
                     println("trailingContentPlaceable x: $it")
                 },
                 y = 0,


### PR DESCRIPTION
## 새로운 기능

1. https://github.com/sungbinland/duckie-quack-quack/pull/81 에 이어지는 작업 입니다.
2. TextField 사이즈 관련 문제는 해결하였습니다. 단, decoraton item 들의 사이즈가 모두 TextField 의 높이로 맞춰짐과 height 가 명시된다는 가정 하에 입니다. 따라서 아래와 같은 형태를 띄게 됩니다.
<img width="50%" alt="QuackBasicTextField 오버레이" src="https://user-images.githubusercontent.com/40740128/189484285-7d05ccbe-183d-4a0f-abe2-9ee164f3087c.png" />

## 새로운 버그

1. 높이를 명시적으로 지정하지 않고 wrap_content 로 한다면 높이가 항상 0 으로 고정되는 문제가 있습니다.
2. decoration item 들의 사이즈가 아래 사진과 같이 항상 정사각형이 아닌 경우를 고려해야 합니다. 현재는 모두 정사각형으로 구현돼 있습니다.
<img width="50%" src="https://user-images.githubusercontent.com/40740128/189484451-37b34f8a-3a1e-4213-a7c4-cf1d30a17b65.png" />

## 추후 할 수 있는 일

- 기존 Material 의 TextField 구현 참고해서 leadingIcon 과 trailingIcon 구현 원리 그대로 적용해 보기

## 참고

- TextField 를 구현하기 위해선 시간이 많이 소요될 거 같아 다른 컴포넌트들을 먼저 만들기 위해 개발중 상태로 PR 을 올립니다.
- 기존 구현된 부분에 덕키 린트 규칙이 모두 반영되지 않아서 CI 가 실패합니다. 추후 리펙토링이 필요합니다.
- 일부 out-of-date 된 주석이 있습니다.
