### PR TITLE
Refactor/fix new line argument

### DIFF
--- a/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/ComposeIssueRegistry.kt
+++ b/lint-compose/src/main/kotlin/team/duckie/quackquack/lint/compose/ComposeIssueRegistry.kt
@@ -21,6 +21,6 @@ class ComposeIssueRegistry : IssueProvider(
         PreferredImmutableCollectionsIssue,
         TrailingCommaIssue,
         FixedModifierOrderIssue,
-        // NewLineArgumentIssue, FIXME: https://sungbinland.slack.com/archives/C03TU31GSM7/p1662903765433469
+        NewLineArgumentIssue,
     ),
 )

--- a/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/NewLineArgumentTest.kt
+++ b/lint-compose/src/test/kotlin/team/duckie/quackquack/lint/compose/NewLineArgumentTest.kt
@@ -20,6 +20,7 @@ import team.duckie.quackquack.common.lint.test.composableTestFile
  * 2. parameter가 전부 new line에 배치되여야 함
  * 3. argument가 전부 new line 배치되어야 함
  * 4. last argument가 LAMDA_EXPRESSION일 경우 에러가 발생되지 않아야 함
+ * 5. argument type이 REFERENCES_EXPRESSION일 경우 에러가 발생되지 않아야 함
  */
 class NewLineArgumentTest {
 
@@ -33,18 +34,6 @@ class NewLineArgumentTest {
                 composableTestFile(
                     """
                             @Composable
-                            fun failed1(a: String,) {}
-
-                            @Composable
-                            fun failed2(
-                                a: String, b: String,
-                                c: String,
-                            ) {}
-
-                            @Composable
-                            fun failed3(a: String, b: String, c: String,) {}
-
-                            @Composable
                             fun success1() {}
 
                             @Composable
@@ -57,6 +46,18 @@ class NewLineArgumentTest {
                                 b: String,
                                 c: String,
                             ) {}
+
+                            @Composable
+                            fun failed1(a: String,) {}
+
+                            @Composable
+                            fun failed2(
+                                a: String, b: String,
+                                c: String,
+                            ) {}
+
+                            @Composable
+                            fun failed3(a: String, b: String, c: String,) {}
                     """.trimIndent()
                 )
             ),
@@ -77,6 +78,11 @@ class NewLineArgumentTest {
 
                             @Composable
                             fun success1() {
+                                val animationFlows: List<Flow<*>> = animationStates.map(State<*>::toFlow)
+                            }
+
+                            @Composable
+                            fun success2() {
                                 test(
                                     a = "example",
                                     b = 1000,
@@ -86,7 +92,7 @@ class NewLineArgumentTest {
                             }
 
                             @Composable
-                            fun success2() {
+                            fun success3() {
                                 test(
                                     a = "test",
                                     b = 1000,
@@ -94,7 +100,7 @@ class NewLineArgumentTest {
                             }
 
                             @Composable
-                            fun success3() {
+                            fun success4() {
                                 test(
                                     a = "test",
                                     b = 1000,

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tab.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tab.kt
@@ -265,7 +265,9 @@ private fun QuackMainTabTextLazyRow(
             QuackText(
                 modifier = tabModifier,
                 text = title,
-                style = QuackSelectedTabTextStyle(index == selectedTabIndex),
+                style = QuackSelectedTabTextStyle(
+                    index == selectedTabIndex
+                ),
             )
         }
     }

--- a/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
+++ b/ui-components/src/main/kotlin/team/duckie/quackquack/ui/component/tag.kt
@@ -88,7 +88,9 @@ fun QuackBoldTag(
     ) {
         QuackTitle2(
             text = text,
-            color = getTagTextColor(isSelected),
+            color = getTagTextColor(
+                isSelected
+            ),
         )
     }
 }
@@ -115,7 +117,9 @@ fun QuackSimpleTag(
     ) {
         QuackBody1(
             text = text,
-            color = getTagTextColor(isSelected),
+            color = getTagTextColor(
+                isSelected
+            ),
         )
     }
 }
@@ -162,7 +166,9 @@ fun QuackIconTag(
             )
             QuackImage(
                 icon = icon,
-                tint = getIconColor(isSelected),
+                tint = getIconColor(
+                    isSelected
+                ),
                 onClick = onClickIcon,
             )
         }


### PR DESCRIPTION
## What's new?

1. NewLineArgument에서 TreeParent이 null이 올 경우 return 처리
2. NewLineArgument에서 인자 타입이 REFERENCES_EXPRESSION일 경우 예외적 허용
3. 2번에 맞게 test코드 update

### 참고
* 해당 branch는 #92 에서 만든 branch입니다. 따라서 해당 branch의 작업물이 포함되어 있습니다
## 체크 리스트

- [x] Reviewer 과 Assignees 를 확인했습니다.
- [x] label 을 확인했습니다
