### PR TITLE
chore: kover 빌드 에러 해결

### DIFF
--- a/lint-compose-publish/build.gradle.kts
+++ b/lint-compose-publish/build.gradle.kts
@@ -15,6 +15,7 @@ import team.duckie.quackquack.convention.QuackArtifactType
 plugins {
     id(ConventionEnum.AndroidLibrary)
     id(ConventionEnum.AndroidQuackPublish)
+    id(ConventionEnum.JvmKover)
 }
 
 android {

--- a/lint-core-publish/build.gradle.kts
+++ b/lint-core-publish/build.gradle.kts
@@ -12,6 +12,7 @@ import team.duckie.quackquack.convention.QuackArtifactType
 plugins {
     id(ConventionEnum.AndroidLibrary)
     id(ConventionEnum.AndroidQuackPublish)
+    id(ConventionEnum.JvmKover)
 }
 
 android {

--- a/lint-quack-publish/build.gradle.kts
+++ b/lint-quack-publish/build.gradle.kts
@@ -12,6 +12,7 @@ import team.duckie.quackquack.convention.QuackArtifactType
 plugins {
     id(ConventionEnum.AndroidLibrary)
     id(ConventionEnum.AndroidQuackPublish)
+    id(ConventionEnum.JvmKover)
 }
 
 android {

--- a/quack-publish-bom/build.gradle.kts
+++ b/quack-publish-bom/build.gradle.kts
@@ -10,6 +10,7 @@
 plugins {
     id(ConventionEnum.AndroidLibrary)
     // id(ConventionEnum.AndroidQuackPublish)
+    id(ConventionEnum.JvmKover)
 }
 
 android {


### PR DESCRIPTION
## Overview (Required)

- "Can't create Kover merge tasks: Kover plugin not applied in projects [:lint-compose-publish, :lint-core-publish, :lint-quack-publish, :quack-publish-bom]" 문제 해결